### PR TITLE
Add message draft feature and fix composer text view issues

### DIFF
--- a/Revolt.xcodeproj/project.pbxproj
+++ b/Revolt.xcodeproj/project.pbxproj
@@ -2535,7 +2535,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.1;
 				NEW_SETTING = "";
 				NEW_SETTING1 = "";
 				ON_DEMAND_RESOURCES_INITIAL_INSTALL_TAGS = Resources;
@@ -2599,7 +2599,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.1;
 				NEW_SETTING = "";
 				NEW_SETTING1 = "";
 				ON_DEMAND_RESOURCES_INITIAL_INSTALL_TAGS = Resources;

--- a/Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+Extensions.swift
+++ b/Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+Extensions.swift
@@ -112,6 +112,11 @@ extension MessageableChannelViewController {
         scrollCheckTimer?.invalidate()
         scrollCheckTimer = nil
 
+        // Draft: save composer text before cleanup (same conditions as above—we did not early return)
+        if let text = messageInputView?.textView.text {
+            viewModel.viewState.saveDraft(channelId: viewModel.channel.id, text: text)
+        }
+
         // CRITICAL FIX: Cleanup MessageInputView references to prevent memory leaks
         messageInputView?.cleanup()
 

--- a/Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+Lifecycle.swift
+++ b/Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+Lifecycle.swift
@@ -292,6 +292,8 @@ extension MessageableChannelViewController {
         // IMMEDIATE: Cancel all pending operations first
         scrollToBottomWorkItem?.cancel()
         scrollToBottomWorkItem = nil
+        draftSaveWorkItem?.cancel()
+        draftSaveWorkItem = nil
         scrollProtectionTimer?.invalidate()
         scrollProtectionTimer = nil
         loadingTask?.cancel()

--- a/Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+TextView.swift
+++ b/Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+TextView.swift
@@ -31,6 +31,14 @@ extension MessageableChannelViewController: UITextViewDelegate {
             
             // Then forward to the original MessageInputView's method
             messageInputView.textViewDidChange(textView)
+            // Draft: debounced save (step 2b)
+            draftSaveWorkItem?.cancel()
+            let channelId = viewModel.channel.id
+            let workItem = DispatchWorkItem { [weak self] in
+                self?.viewModel.viewState.saveDraft(channelId: channelId, text: text)
+            }
+            draftSaveWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: workItem)
         } else {
             // print("DEBUG: This is NOT the messageInputView's textView. Current textView: \(textView)")
             // print("DEBUG: Our messageInputView.textView: \(messageInputView.textView)")

--- a/Revolt/Pages/Channel/Messagable/MessageableChannelViewController.swift
+++ b/Revolt/Pages/Channel/Messagable/MessageableChannelViewController.swift
@@ -74,6 +74,8 @@ class MessageableChannelViewController: UIViewController, UITextFieldDelegate,
 
     // Properties moved from managers for compatibility
     var scrollToBottomWorkItem: DispatchWorkItem?
+    /// Debounced draft save (step 2b); cancelled on disappear.
+    var draftSaveWorkItem: DispatchWorkItem?
     var lastManualScrollTime: Date?
     var lastManualScrollUpTime: Date?
     var scrollProtectionTimer: Timer?
@@ -391,6 +393,11 @@ class MessageableChannelViewController: UIViewController, UITextFieldDelegate,
 
         // Update bouncing behavior in viewWillAppear
         updateTableViewBouncing()
+
+        // Draft: restore stored draft for this channel if any; if no draft, do not clear composer (preserve same-channel return / return-from-search)
+        if let draft = viewModel.viewState.loadDraft(channelId: viewModel.channel.id), !draft.isEmpty {
+            messageInputView.setText(draft)
+        }
     }
 
     /// Performs INSTANT memory cleanup - no delays, no async operations

--- a/Revolt/Pages/Channel/Messagable/Utils/MessageInputHandler.swift
+++ b/Revolt/Pages/Channel/Messagable/Utils/MessageInputHandler.swift
@@ -105,6 +105,7 @@ class MessageInputHandler: NSObject, UIDocumentPickerDelegate, UIImagePickerCont
         } else {
             print("Internet Monitor: 😭 😭 😭 😭 😭 Internet not available")
             queueMessage(convertedText)
+            viewModel.viewState.clearDraft(channelId: viewModel.channel.id)
             print("Message sent to Queue: ✅ ✅ ✅ ✅ ✅")
             viewController.showErrorAlert(message: "You're offline. Will send when internet comes back.")
             print("Alert Sent to user: ⚠️ ⚠️ ⚠️ ⚠️ ⚠️")
@@ -147,6 +148,7 @@ class MessageInputHandler: NSObject, UIDocumentPickerDelegate, UIImagePickerCont
             
             // Store the temporary message in the messages dictionary for rendering
             viewModel.viewState.messages[messageNonce] = queuedMessage.toTemporaryMessage()
+            viewModel.viewState.clearDraft(channelId: viewModel.channel.id)
             
             print("📝 MESSAGE_INPUT_HANDLER: Sending with \(apiReplies.count) replies")
             
@@ -276,6 +278,7 @@ class MessageInputHandler: NSObject, UIDocumentPickerDelegate, UIImagePickerCont
             
             // Store the temporary message in the messages dictionary for rendering
             viewModel.viewState.messages[messageNonce] = queuedMessage.toTemporaryMessage()
+            viewModel.viewState.clearDraft(channelId: viewModel.channel.id)
             
             print("📝 MESSAGE_INPUT_HANDLER: Sending with \(apiReplies.count) replies")
             

--- a/Revolt/ViewState+Extensions/ViewState+Auth.swift
+++ b/Revolt/ViewState+Extensions/ViewState+Auth.swift
@@ -46,7 +46,7 @@ extension ViewState {
          }*/
         // IMPORTANT: do not destroy the cache/session here. It'll cause the app to crash before it can transition to the welcome screen.
         // The cache is destroyed in RevoltApp.swift:ApplicationSwitcher
-        
+        clearAllDraftsForCurrentAccount()
         state = .signedOut
         return .success(())
     }
@@ -127,6 +127,7 @@ extension ViewState {
     }
     
     func destroyCache() {
+        clearAllDraftsForCurrentAccount()
         // Flush pending cache writes with bounded timeout, then invalidate writer and clear message cache
         print("📂 [MessageCache] Invalidating writer and clearing cache (sign-out)")
         MessageCacheWriter.shared.invalidate(flushFirst: true)

--- a/Revolt/ViewState+Extensions/ViewState+Drafts.swift
+++ b/Revolt/ViewState+Extensions/ViewState+Drafts.swift
@@ -1,0 +1,71 @@
+//
+//  ViewState+Drafts.swift
+//  Revolt
+//
+//  Draft message storage (composer text per channel). Session-bound; loaded in processReadyData, cleared in signOut/destroyCache.
+//
+
+import Foundation
+
+private let draftMaxLength = 2000
+private let channelDraftsKeyPrefix = "channelDrafts_"
+
+extension ViewState {
+
+    /// UserDefaults key for current account's drafts. Nil if session not bound.
+    private func draftStorageKey() -> String? {
+        guard let userId = currentUser?.id, let base = baseURL, !userId.isEmpty, !base.isEmpty else { return nil }
+        return "\(channelDraftsKeyPrefix)\(userId)_\(base)"
+    }
+
+    /// Load drafts from UserDefaults for the given account into in-memory channelDrafts. Call from processReadyData after setSession.
+    func loadDraftsFromUserDefaults(userId: String, baseURL: String) {
+        let key = "\(channelDraftsKeyPrefix)\(userId)_\(baseURL)"
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let decoded = try? JSONDecoder().decode([String: String].self, from: data) else {
+            channelDrafts = [:]
+            return
+        }
+        channelDrafts = decoded
+    }
+
+    /// Save draft for channel. Nil or empty removes the draft. Caps length at 2000. Persists to UserDefaults. No-op if session not bound.
+    func saveDraft(channelId: String, text: String?) {
+        guard let key = draftStorageKey() else { return }
+        let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let t = trimmed, !t.isEmpty {
+            let capped = String(t.prefix(draftMaxLength))
+            channelDrafts[channelId] = capped
+        } else {
+            channelDrafts.removeValue(forKey: channelId)
+        }
+        if let data = try? JSONEncoder().encode(channelDrafts) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+
+    /// Load draft for channel. Returns nil if none or session not bound.
+    func loadDraft(channelId: String) -> String? {
+        guard draftStorageKey() != nil else { return nil }
+        return channelDrafts[channelId]
+    }
+
+    /// Clear draft for one channel. Persists. No-op if session not bound.
+    func clearDraft(channelId: String) {
+        guard let key = draftStorageKey() else { return }
+        channelDrafts.removeValue(forKey: channelId)
+        if let data = try? JSONEncoder().encode(channelDrafts) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+
+    /// Clear all drafts for the current account (in-memory and UserDefaults). Call from signOut and at start of destroyCache.
+    func clearAllDraftsForCurrentAccount() {
+        guard let key = draftStorageKey() else {
+            channelDrafts = [:]
+            return
+        }
+        channelDrafts = [:]
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+}

--- a/Revolt/ViewState+Extensions/ViewState+ReadyEvent.swift
+++ b/Revolt/ViewState+Extensions/ViewState+ReadyEvent.swift
@@ -156,6 +156,7 @@ extension ViewState {
         ws?.retryCount = 0
         if let uid = currentUser?.id, let url = baseURL {
             MessageCacheWriter.shared.setSession(userId: uid, baseURL: url)
+            loadDraftsFromUserDefaults(userId: uid, baseURL: url)
         }
         
         await verifyStateIntegrity()

--- a/Revolt/ViewState.swift
+++ b/Revolt/ViewState.swift
@@ -213,6 +213,8 @@ public class ViewState: ObservableObject {
     @Published var state: ConnectionState = .connecting
     @Published var forceMainScreen: Bool = false
     @Published var queuedMessages: [String: [QueuedMessage]] = [:]
+    /// Per-channel draft text (composer only). Session-bound; loaded in processReadyData, cleared in signOut/destroyCache.
+    var channelDrafts: [String: String] = [:]
     @Published var loadingMessages: Set<String> = Set()
     @Published var currentlyTyping: [String: OrderedSet<String>] = [:]
     @Published var isOnboarding: Bool = false


### PR DESCRIPTION
## Summary

Adds a per-channel message draft feature and fixes several composer text view bugs discovered during testing.

## What's new

### Message Drafts
- **Per-channel draft persistence**: Composer text is saved per channel in UserDefaults, keyed by `channelDrafts_{userId}_{baseURL}` so each account has its own drafts with no cross-account leakage.
- **Session-bound**: Drafts are loaded in `processReadyData` after the WebSocket Ready event, and cleared in both `signOut()` and at the very start of `destroyCache()` for a lifecycle-robust sign-out guarantee.
- **Save on leave**: Draft is saved in `viewDidDisappear` before `messageInputView.cleanup()`. Skipped when `isReturningFromSearch` or same-channel target-message.
- **Restore on enter**: Draft is restored in `viewWillAppear`. If nil/empty, the composer is not cleared — preserves in-memory text on same-channel return and return-from-search.
- **Clear at commit-to-send**: Draft is cleared in `MessageInputHandler` at commit time (offline queued, online, and attachment send), not only after API success.
- **Debounced save while typing**: 1.5 s debounced save in `textViewDidChange` so drafts survive force-quit/backgrounding. Work item is cancelled in `viewWillDisappear`.

## Bug fixes

**Fix 1** — Send button disabled after draft restore: `setText()` now calls `updateSendButtonState()` so the send button is enabled immediately when a draft is restored.

**Fix 2** — Compiler error (invalid redeclaration of `text` in debounce block): Removed duplicate `let text` declaration in `textViewDidChange`.

**Fix 3** — Send button enabled for whitespace-only input: `updateSendButtonState()` and `sendButtonTapped()` now trim whitespace before checking for content.

**Fix 4** — Restored long multi-line draft renders as single line: `updateTextViewHeight()` uses a container-width fallback when `textView.frame.width` is 0; `layoutSubviews()` re-calls `updateTextViewHeight()` when text is non-empty.

**Fix 5** — Scrolling disabled for restored long draft: `isScrollEnabled` is set to `true` before assigning text in `setText()`; toggled at `maxHeight` to force `UITextView` `contentSize` recompute.

## Files changed

- `Revolt/ViewState+Extensions/ViewState+Drafts.swift` — new file, core draft API
- `Revolt/ViewState.swift` — added `channelDrafts` property
- `Revolt/ViewState+Extensions/ViewState+Auth.swift` — clear drafts on sign-out
- `Revolt/ViewState+Extensions/ViewState+ReadyEvent.swift` — load drafts on Ready event
- `Revolt/Pages/Channel/Messagable/Views/MessageInputView.swift` — Fixes 1–5
- `Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+Extensions.swift` — save on leave
- `Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+Lifecycle.swift` — cancel debounce on leave
- `Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+TextView.swift` — debounced save
- `Revolt/Pages/Channel/Messagable/MessageableChannelViewController.swift` — restore on enter
- `Revolt/Pages/Channel/Messagable/Utils/MessageInputHandler.swift` — clear at commit
- `AGENTS.md` — updated documentation

## Testing performed

TC-01 to TC-23 (core save/restore, channel isolation, navigation edge cases, online/offline send, sign-out, multi-account): all passed.  
TC-06 (long draft multiline restore): passed after Fix 4 + Fix 5.  
TC-24 (baseURL/instance isolation): not yet run — requires a second server instance.
