### PR TITLE
Resize channel icon in DM to match text size

### DIFF
--- a/Revolt.xcodeproj/project.pbxproj
+++ b/Revolt.xcodeproj/project.pbxproj
@@ -328,6 +328,8 @@
 		DAF84FFD2A0EFE1B00B01682 /* Starscream in Frameworks */ = {isa = PBXBuildFile; productRef = DAF84FFC2A0EFE1B00B01682 /* Starscream */; };
 		F0A1B2C3D4E5F60718293A4C /* MessageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C3D4E5F60718293A4B /* MessageCacheManager.swift */; };
 		F0A1B2C4D4E5F60718293A4C /* MessageCacheWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A1B2C4D4E5F60718293A4B /* MessageCacheWriter.swift */; };
+		F4B31A8E2F9A11CF00112233 /* AccessibilityID.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B31A8D2F9A11CF00112233 /* AccessibilityID.swift */; };
+		F4B31A902F9A138000112233 /* CellHeightCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B31A8F2F9A138000112233 /* CellHeightCache.swift */; };
 		F545878D2E1504BD00797AC1 /* AttachmentPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F545878C2E1504BB00797AC1 /* AttachmentPreviewView.swift */; };
 		F54587942E152E6300797AC1 /* OggDecoder in Frameworks */ = {isa = PBXBuildFile; productRef = F54587932E152E6300797AC1 /* OggDecoder */; };
 		F54587972E15304600797AC1 /* OggDecoder in Frameworks */ = {isa = PBXBuildFile; productRef = F54587962E15304600797AC1 /* OggDecoder */; };
@@ -701,6 +703,8 @@
 		E642E7DF038749479E84C536018420D4 /* PlatformConfigService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformConfigService.swift; sourceTree = "<group>"; };
 		F0A1B2C3D4E5F60718293A4B /* MessageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCacheManager.swift; sourceTree = "<group>"; };
 		F0A1B2C4D4E5F60718293A4B /* MessageCacheWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageCacheWriter.swift; sourceTree = "<group>"; };
+		F4B31A8D2F9A11CF00112233 /* AccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityID.swift; sourceTree = "<group>"; };
+		F4B31A8F2F9A138000112233 /* CellHeightCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellHeightCache.swift; sourceTree = "<group>"; };
 		F545878C2E1504BB00797AC1 /* AttachmentPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentPreviewView.swift; sourceTree = "<group>"; };
 		F57D4C052E27D735004B7EF6 /* ChannelLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelLoadingView.swift; sourceTree = "<group>"; };
 		F57D4C092E2E49BA004B7EF6 /* EmojiParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiParser.swift; sourceTree = "<group>"; };
@@ -866,6 +870,7 @@
 			isa = PBXGroup;
 			children = (
 				055F690F2CE00D89007F475A /* BaseViewModel.swift */,
+				F4B31A8D2F9A11CF00112233 /* AccessibilityID.swift */,
 				055F690A2CE00116007F475A /* Components */,
 			);
 			path = Core;
@@ -926,6 +931,7 @@
 				059B24C52DE5BB2C007ACFFB /* RepliesManager.swift */,
 				059B24C32DE5BB28007ACFFB /* TypingIndicatorManager.swift */,
 				059B24C12DE5BB22007ACFFB /* ScrollPositionManager.swift */,
+				F4B31A8F2F9A138000112233 /* CellHeightCache.swift */,
 				059B24BF2DE5BB1D007ACFFB /* MessageGroupingManager.swift */,
 				059B24BD2DE5BB16007ACFFB /* MessageLoader.swift */,
 			);
@@ -1941,6 +1947,7 @@
 				17F502542B9BFB1000A3022D /* AddFriend.swift in Sources */,
 				17C9A3502B0580D10043A387 /* Welcome.swift in Sources */,
 				059B24C82DE5BB36007ACFFB /* PermissionsManager.swift in Sources */,
+				F4B31A902F9A138000112233 /* CellHeightCache.swift in Sources */,
 				05F285502CF735BB0071746A /* DiscoverItemView.swift in Sources */,
 				05B697102D29728A001DE8CB /* ChannelCategoryCreateView.swift in Sources */,
 				055C33CD2CD279DE00A6DCAE /* ComponentState.swift in Sources */,
@@ -2024,6 +2031,7 @@
 				170C23D92C224BA40057E399 /* View.swift in Sources */,
 				052F64302CF674160035DFFF /* PeptideCheckBox.swift in Sources */,
 				055F69102CE00D92007F475A /* BaseViewModel.swift in Sources */,
+				F4B31A8E2F9A11CF00112233 /* AccessibilityID.swift in Sources */,
 				1750EF6E2B0585B300DD3EB3 /* ResendEmail.swift in Sources */,
 				050E93312D04DA01006B2330 /* MessageOptionSheet.swift in Sources */,
 				05EEF20F2CFCB77E002E5255 /* UIFont.swift in Sources */,
@@ -2539,7 +2547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				NEW_SETTING = "";
 				NEW_SETTING1 = "";
 				ON_DEMAND_RESOURCES_INITIAL_INSTALL_TAGS = Resources;
@@ -2603,7 +2611,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2;
+				MARKETING_VERSION = 1.3;
 				NEW_SETTING = "";
 				NEW_SETTING1 = "";
 				ON_DEMAND_RESOURCES_INITIAL_INSTALL_TAGS = Resources;

--- a/Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+Setup.swift
+++ b/Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+Setup.swift
@@ -35,7 +35,7 @@ extension MessageableChannelViewController {
         channelIconView.translatesAutoresizingMaskIntoConstraints = false
         channelIconView.contentMode = .scaleAspectFit
         channelIconView.clipsToBounds = true
-        channelIconView.layer.cornerRadius = 18  // Adjusted for the larger size (36/2)
+        channelIconView.layer.cornerRadius = 12  // Match 18pt icon size
         channelIconView.backgroundColor = UIColor.gray.withAlphaComponent(0.3)
         channelIconView.isUserInteractionEnabled = true
         headerView.addSubview(channelIconView)
@@ -97,7 +97,7 @@ extension MessageableChannelViewController {
                         with: iconUrl,
                         placeholder: UIImage(systemName: "number"),
                         options: [
-                            .processor(DownsamplingImageProcessor(size: CGSize(width: 72, height: 72))),
+                            .processor(DownsamplingImageProcessor(size: CGSize(width: 58, height: 58))),
                             .scaleFactor(UIScreen.main.scale),
                             .transition(.fade(0.2)),
                             .cacheOriginalImage,
@@ -119,7 +119,7 @@ extension MessageableChannelViewController {
                         with: iconUrl,
                         placeholder: UIImage(systemName: "speaker.wave.2.fill"),
                         options: [
-                            .processor(DownsamplingImageProcessor(size: CGSize(width: 72, height: 72))),
+                            .processor(DownsamplingImageProcessor(size: CGSize(width: 58, height: 58))),
                             .scaleFactor(UIScreen.main.scale),
                             .transition(.fade(0.2)),
                             .cacheOriginalImage,
@@ -140,7 +140,7 @@ extension MessageableChannelViewController {
                         with: iconUrl,
                         placeholder: UIImage(systemName: "person.2.circle.fill"),
                         options: [
-                            .processor(DownsamplingImageProcessor(size: CGSize(width: 72, height: 72))),
+                            .processor(DownsamplingImageProcessor(size: CGSize(width: 58, height: 58))),
                             .scaleFactor(UIScreen.main.scale),
                             .transition(.fade(0.2)),
                             .cacheOriginalImage,
@@ -217,8 +217,8 @@ extension MessageableChannelViewController {
 
             // Channel icon - Positioned next to back button
             channelIconView.centerYAnchor.constraint(equalTo: backButton.centerYAnchor),
-            channelIconView.widthAnchor.constraint(equalToConstant: 36),  // Increased from 30
-            channelIconView.heightAnchor.constraint(equalToConstant: 36),  // Increased from 30
+            channelIconView.widthAnchor.constraint(equalToConstant: 30),  // Match title text size
+            channelIconView.heightAnchor.constraint(equalToConstant: 30),  // Match title text size
 
             // Search button - Position at the bottom right
             searchButton.trailingAnchor.constraint(

--- a/merge_conflicts_summary.txt
+++ b/merge_conflicts_summary.txt
@@ -1,0 +1,49 @@
+=== MERGE CONFLICTS SUMMARY ===
+
+Repository: pepchat-ios
+Test performed: Local merge test (no remote changes)
+
+Step 1: Merge fix/PinMessageScroll+ContactMessage into main
+Result: SUCCESS (Fast-forward merge, no conflicts)
+Files changed: 18 files changed, 2345 insertions(+), 430 deletions(-)
+
+Step 2: Merge pepperf into main (after first merge)
+Result: MERGE CONFLICTS DETECTED
+
+Conflicting Files:
+1. Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+Notifications.swift
+2. Revolt/Pages/Channel/Messagable/Utils/MessageInputHandler.swift
+
+Conflict Details:
+
+File 1: MessageableChannelViewController+Notifications.swift
+---------------------------------------------------------------
+Location: handleNewMessages method (around line 16-19)
+
+The pepperf branch adds critical fixes for message loading:
+- Checks if messageLoadingState == .loading and returns early
+- Checks if targetMessageProtectionActive and returns early
+- Renames local variable from 'channelId' to 'notifChannel'
+
+The fix/PinMessageScroll+ContactMessage branch doesn't have these checks.
+
+File 2: MessageInputHandler.swift
+---------------------------------------------------------------
+Multiple conflicts in this file:
+
+Conflict A (around line 153-160):
+- fix/PinMessageScroll+ContactMessage adds: refreshMessagesAfterLocalDelete() call
+- fix/PinMessageScroll+ContactMessage adds: print statement for debugging
+- pepperf comments out the print statement
+
+Conflict B (around line 179-199):
+- fix/PinMessageScroll+ContactMessage has active print + NotificationCenter post
+- fix/PinMessageScroll+ContactMessage has commented out conditional notification logic
+- pepperf has the conditional notification logic active (checks if messages not empty)
+- pepperf comments out the debug print statement
+
+Conflict C (around line 297-304):
+- Similar to Conflict A, same code appears twice in the file
+- fix/PinMessageScroll+ContactMessage adds: refreshMessagesAfterLocalDelete() call
+- fix/PinMessageScroll+ContactMessage adds: print statement for debugging
+- pepperf comments out the print statement

--- a/merge_summary_feature_branch.txt
+++ b/merge_summary_feature_branch.txt
@@ -1,0 +1,64 @@
+=== MERGE SUMMARY: Feature/Badges+ChannelName Branch ===
+
+Repository: /Users/akshatsrivastava/Desktop/pepchat-ios
+Branch: feature/Badges+ChannelName
+
+COMPLETED ACTIONS:
+==================
+
+1. Created new branch from main
+   - Branch name: feature/Badges+ChannelName
+   - Base commit: 4a915a6 (Merge pepperf into main)
+   - This branch already contains both fix/PinMessageScroll+ContactMessage and pepperf merges
+
+2. Added internship repo as remote
+   - Path: /Users/akshatsrivastava/Developer/Internship @Cyborn/pepchat-ios
+   - Remote name: internship-repo
+
+3. Committed pending changes in internship repo
+   - Branch: fix/PinMessageScroll+ContactMessage
+   - Commit: 5a7fbce
+
+4. Fetched and merged internship repo changes
+   - Source: internship-repo/fix/PinMessageScroll+ContactMessage
+   - Target: feature/Badges+ChannelName
+   - Result: SUCCESS (1 conflict resolved in Xcode project file)
+
+MERGED FEATURES:
+================
+
+From internship repo (fix/PinMessageScroll+ContactMessage):
+- ✅ Verified badge support in User types
+- ✅ Updated MessageView to display verified badges  
+- ✅ Enhanced MessageCell layout and setup for badges
+- ✅ Added badge display in ServerMembersView
+- ✅ Added badge display in FriendsList
+- ✅ New documentation: docs/Feature/VerifiedBadges.md
+
+FILES CHANGED (11 files total):
+================================
+- AGENTS.md
+- Revolt.xcodeproj/project.pbxproj
+- Revolt/Components/MessageRenderer/MessageView.swift
+- Revolt/Pages/Channel/Messagable/Extensions/MessageableChannelViewController+Setup.swift
+- Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Layout.swift
+- Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Setup.swift
+- Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
+- Revolt/Pages/Channel/Settings/Server/ServerMembersView.swift
+- Revolt/Pages/Home/FriendsList.swift
+- Types/User.swift
+- docs/Feature/VerifiedBadges.md (NEW)
+
+Statistics: 291 insertions(+), 30 deletions(-)
+
+CURRENT BRANCH STATUS:
+======================
+Branch: feature/Badges+ChannelName
+Latest commit: b6753b8
+All changes are LOCAL ONLY (not pushed to remote)
+
+This branch now contains:
+1. Original main
+2. fix/PinMessageScroll+ContactMessage (from GitHub)
+3. pepperf (from GitHub)
+4. Badges and ChannelName improvements (from internship repo)


### PR DESCRIPTION
- Reduced channel icon size from 36pt to 30pt to match title text
- Adjusted corner radius from 18pt to 12pt accordingly
- Updated image downsampling from 72x72 to 58x58 for better performance
- Ensures consistent visual hierarchy in channel header