### PR TITLE
Support @everyone mentions on iOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,3 +184,34 @@ API docs: https://developers.revolt.chat/developers/endpoints.html
 - **Save attachment to Photos**: `FullScreenImageViewController` (`Messagable/Controllers/`) saves the displayed image (preferring original URL/data with auth when available) via `PHPhotoLibrary` add-only authorization. In-composer pending files remain `PendingAttachmentsManager` / `1PendingAttachmentsManager.swift`.
 - **API history reconcile**: When merging fetched messages in `MessageableChannelViewController+MessageLoading.swift`, only treat cache-only IDs as server-deleted if the API page is full (100 messages); otherwise older local IDs may simply be off the end of the fetched window.
 
+## Shared `@everyone` QA Accounts
+
+Use these persistent production QA accounts for cross-client `@everyone` testing. Do not create
+duplicates, change their Archem roles, or delete them. Passwords are stored in the macOS login
+Keychain and must never be pasted into source, logs, test reports, commits, or chat.
+
+- API: `https://peptide.chat/api`
+- Server: Archem Team (`01J8W7NPV2DM3XR48JAYB1RDFK`)
+- Channel: `testing` (`01J8Y8T3XQ75D9KW32CG522952`)
+- Allowed sender: `qa-ios-everyone-sender-20260806@peptide.chat`, username
+  `ios_everyone_sender`, user `01KZBZP1BQ8603X1NKW721W732`, Keychain service
+  `pepchat-ios.qa.everyone.sender`
+- Denied sender: `qa-ios-everyone-denied-20260806@peptide.chat`, username
+  `ios_everyone_denied`, user `01KZBZP401HX40WWT9P4QGPEG7`, Keychain service
+  `pepchat-ios.qa.everyone.denied`
+- Recipient: `qa-ios-everyone-recipient-20260806@peptide.chat`, username
+  `ios_everyone_recipient`, user `01KZBZP60EV4M26MVXE5NZF040`, Keychain service
+  `pepchat-ios.qa.everyone.recipient`
+
+Retrieve a password directly into a shell variable without displaying it:
+
+```bash
+test_password="$(security find-generic-password -w -s '<keychain-service>' -a '<email>')"
+```
+
+The allowed account has the dedicated `iOS @everyone QA allowed` role; the denied account has the
+dedicated deny role; the recipient has neither. Expected server behavior: allowed `@everyone`
+messages have `flags: 2` and enter the recipient's unread `mentions`; manually typed text from the
+denied account may send successfully but has no everyone flag and must not create a mention. The
+latest non-secret session manifest is
+`.codex/test-sessions/pepchat-everyone-latest.json` (local and git-ignored).

--- a/Revolt/Components/Contents.swift
+++ b/Revolt/Components/Contents.swift
@@ -1604,25 +1604,22 @@ struct InnerContents: UIViewRepresentable {
     // Process user mentions: <@user_id>
     private func processUserMentions(in attrString: NSMutableAttributedString, textview: UITextView) {
         // FIXED: Collect matches first to avoid offset calculation issues
-        let userMentionMatches = Array(attrString.string.matches(of: /<@(\w{26})>/))
+        let userMentionMatches = Array(attrString.string.matches(of: /<@([A-Za-z0-9]+)>/))
         
         for match in userMentionMatches.reversed() {
             let id = match.output.1
             
-            if let user = viewState.users[String(id)] {
-                let member = currentServer.flatMap { viewState.members[$0.id]![user.id] }
-                
-                // Safely calculate the offset using NSRange instead of utf16Offset
-                let nsRange = NSRange(match.range, in: attrString.string)
-                guard nsRange.location != NSNotFound && 
-                      nsRange.location >= 0 && 
-                      nsRange.location + nsRange.length <= attrString.length else {
-                    continue
-                }
-                
-                let currentAttrs = attrString.attributes(at: nsRange.location, effectiveRange: nil)
-                let currentFont = (currentAttrs[.font] ?? contentFont) as! UIFont
-                
+            let nsRange = NSRange(match.range, in: attrString.string)
+            guard nsRange.location != NSNotFound,
+                  nsRange.location >= 0,
+                  nsRange.location + nsRange.length <= attrString.length else {
+                continue
+            }
+
+            let currentAttrs = attrString.attributes(at: nsRange.location, effectiveRange: nil)
+            let currentFont = (currentAttrs[.font] as? UIFont) ?? contentFont
+
+            if let user = viewState.users[String(id)] ?? viewState.allEventUsers[String(id)] {
                 attrString.deleteCharacters(in: nsRange)
                     
                 let username = NSMutableAttributedString(string: "@\(user.display_name ?? user.username)", attributes: [.font: currentFont])
@@ -1632,6 +1629,13 @@ struct InnerContents: UIViewRepresentable {
                 ], range: NSRange(location: 0, length: username.length))
                                 
                 attrString.insert(username, at: nsRange.location)
+            } else {
+                let fallback = "@unknown-user"
+                attrString.replaceCharacters(in: nsRange, with: fallback)
+                attrString.addAttributes([
+                    .font: currentFont,
+                    .foregroundColor: UIColor.secondaryLabel
+                ], range: NSRange(location: nsRange.location, length: (fallback as NSString).length))
             }
         }
     }
@@ -2104,5 +2108,4 @@ struct ChatMessageView: View {
     .preferredColorScheme(.dark)
     
 }
-
 

--- a/Revolt/Components/MessageRenderer/MessageAttachment.swift
+++ b/Revolt/Components/MessageRenderer/MessageAttachment.swift
@@ -75,6 +75,7 @@ struct MessageAttachment: View {
     @State var isPresented: Bool = false
     var attachment: File  // The file attachment to be displayed
     var height : CGFloat = 0
+    var usesAdaptiveSingleImageLayout = false
     
     
     var body: some View {
@@ -82,12 +83,29 @@ struct MessageAttachment: View {
         
         Group {
             switch attachment.metadata {
-            case .image(_):  // Handle image attachments
-                
-                
-                /*Button {
-                    self.isPresented.toggle()
-                } label: {*/
+            case .image(let metadata):  // Handle image attachments
+                if usesAdaptiveSingleImageLayout {
+                    let availableWidth = max(1, UIScreen.main.bounds.width - 82)
+                    let previewSize = ImageAttachmentPreviewLayout.singleSize(
+                        sourceSize: CGSize(
+                            width: CGFloat(metadata.width),
+                            height: CGFloat(metadata.height)
+                        ),
+                        availableWidth: availableWidth
+                    )
+
+                    LazyImage(
+                        source: .file(attachment),
+                        clipTo: RoundedRectangle(cornerRadius: .radiusXSmall),
+                        contentMode: .fit
+                    )
+                    .frame(width: previewSize.width, height: previewSize.height)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .onTapGesture {
+                        self.isPresented.toggle()
+                    }
+                } else {
                     Color.clear
                         .overlay {
                             LazyImage(source: .file(attachment),
@@ -103,12 +121,7 @@ struct MessageAttachment: View {
                         .onTapGesture{
                             self.isPresented.toggle()
                         }
-               // }
-                
-                
-                
-                
-                
+                }
             case .video(_):  // Handle video attachments (same UIKit player as chat)
                 let videoURL = viewState.formatUrl(fromId: attachment.id, withTag: "attachments")
                 ChannelVideoAttachmentPlayerView(
@@ -221,9 +234,6 @@ struct ZoomableMessageAttachment : View {
                         .aspectRatio(contentMode: .fit)  // Maintain aspect ratio
                         .frame(maxHeight: 295)  // Set a maximum height for the image
                     }
-                    
-                    
-                   
                     
                     
                 case .video(_):  // Handle video attachments (same UIKit player as chat)

--- a/Revolt/Components/MessageRenderer/MessageContentsView.swift
+++ b/Revolt/Components/MessageRenderer/MessageContentsView.swift
@@ -265,7 +265,11 @@ struct MessageContentsView: View {
                                 if !mediaAttachments.isEmpty {
                                     
                                     if mediaAttachments.count == 1 {
-                                        MessageAttachment(attachment: mediaAttachments[0], height: 295)
+                                        MessageAttachment(
+                                            attachment: mediaAttachments[0],
+                                            height: 295,
+                                            usesAdaptiveSingleImageLayout: true
+                                        )
                                             .padding(.top, .padding4)
                                     } else if mediaAttachments.count == 2 {
                                         

--- a/Revolt/Components/MessageRenderer/MessageEmbed.swift
+++ b/Revolt/Components/MessageRenderer/MessageEmbed.swift
@@ -9,6 +9,59 @@ import SwiftUI
 import Types
 import AVKit
 import WebKit
+import Kingfisher
+
+private struct RemoteEmbedImage: View {
+    private enum Phase {
+        case loading
+        case loaded
+        case failed
+    }
+
+    let url: URL
+    let sourceWidth: Int?
+    let sourceHeight: Int?
+
+    @State private var phase: Phase = .loading
+
+    private var aspectRatio: CGFloat {
+        guard let sourceWidth, let sourceHeight, sourceWidth > 0, sourceHeight > 0 else {
+            return 16.0 / 9.0
+        }
+        return CGFloat(sourceWidth) / CGFloat(sourceHeight)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if phase != .loaded {
+                HStack(spacing: 8) {
+                    if phase == .loading {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: "photo.badge.exclamationmark")
+                    }
+
+                    Text(phase == .loading ? "Loading preview…" : "Preview unavailable")
+                        .font(.caption)
+                }
+                .foregroundStyle(Color.textGray06)
+                .padding(.vertical, 8)
+            }
+
+            if phase != .failed {
+                KFAnimatedImage(source: .network(url))
+                    .placeholder { Color.clear }
+                    .onSuccess { _ in phase = .loaded }
+                    .onFailure { _ in phase = .failed }
+                    .aspectRatio(aspectRatio, contentMode: .fit)
+                    .frame(maxHeight: phase == .loaded ? 240 : 0)
+                    .opacity(phase == .loaded ? 1 : 0)
+                    .clipped()
+            }
+        }
+    }
+}
 
 /// A view that renders different types of message embeds, such as images, videos, text, websites, and special embeds.
 struct MessageEmbed: View {
@@ -45,7 +98,13 @@ struct MessageEmbed: View {
         switch embed {
         case .image(let image):
             // Render an image embed
-            LazyImage(source: .url(URL(string: image.url)!), clipTo: Rectangle())
+            if let url = URL(string: image.url) {
+                RemoteEmbedImage(
+                    url: url,
+                    sourceWidth: image.width,
+                    sourceHeight: image.height
+                )
+            }
         case .video(let video):
             // Render a video embed using AVPlayer
             if let url = URL(string: video.url) {
@@ -120,7 +179,7 @@ struct MessageEmbed: View {
                             
                             // Icon and site name
                             if let icon_url = embed.icon_url, embed.site_name != nil, let url = URL(string: icon_url) {
-                                LazyImage(source: .url(url), height: .size64, width: .size64, clipTo: Rectangle())
+                                LazyImage(source: .url(url), height: .size20, width: .size20, clipTo: Rectangle())
                                     .clipShape(UnevenRoundedRectangle(topLeadingRadius: .radiusXSmall, bottomLeadingRadius: .radiusXSmall, bottomTrailingRadius: .radiusXSmall, topTrailingRadius: .radiusXSmall))
                                     .padding(.top, .padding8)
                             }
@@ -143,7 +202,11 @@ struct MessageEmbed: View {
                             .aspectRatio(CGSize(width: video.width, height: video.height), contentMode: .fit)
                             .frame(maxWidth: CGFloat(integerLiteral: video.width), maxHeight: CGFloat(integerLiteral: video.height))
                     } else if let image = embed.image, image.size == JanuaryImage.Size.large, let url = URL(string: image.url) {
-                            LazyImage(source: .url(url), clipTo: Rectangle())
+                            RemoteEmbedImage(
+                                url: url,
+                                sourceWidth: image.width,
+                                sourceHeight: image.height
+                            )
                             .clipShape(RoundedRectangle(cornerRadius: .radiusXSmall))
                             .padding(.top, .padding8)
                         }
@@ -151,7 +214,11 @@ struct MessageEmbed: View {
                     // Preview image for smaller embeds
                     if let image = embed.image, embed.special == nil || embed.special == WebsiteSpecial.none, embed.video == nil {
                         if image.size == JanuaryImage.Size.preview, let url = URL(string: image.url) {
-                            LazyImage(source: .url(url), clipTo: Rectangle())
+                            RemoteEmbedImage(
+                                url: url,
+                                sourceWidth: image.width,
+                                sourceHeight: image.height
+                            )
                                 .clipShape(RoundedRectangle(cornerRadius: .radiusXSmall))
                                 .padding(.top, .padding8)
                         }

--- a/Revolt/Components/MessageRenderer/MessageReply.swift
+++ b/Revolt/Components/MessageRenderer/MessageReply.swift
@@ -79,12 +79,12 @@ struct InnerMessageReplyView: View {
     func authorBadge(message: Message, author: User) -> (text: String, color: Color)? {
         if author.bot != nil {
             return message.masquerade == nil
-                ? (String(localized: "BOT"), .bgPurple10)
-                : (String(localized: "BRIDGE"), .bgRed07)
+                ? (String(localized: "BOT"), .bgPurple10.opacity(0.8))
+                : (String(localized: "BRIDGE"), .bgGray10.opacity(0.85))
         }
 
         if isNewAccount(author) {
-            return (String(localized: "NEW"), .bgGreen07)
+            return (String(localized: "NEW"), .bgGreen07.opacity(0.75))
         }
 
         return nil
@@ -98,6 +98,23 @@ struct InnerMessageReplyView: View {
 
         let accountAge = Calendar.current.dateComponents([.day], from: ulid.timestamp, to: Date()).day ?? Int.max
         return accountAge <= 14
+    }
+
+    private func attachmentSummary(_ attachments: [Types.File]) -> String {
+        guard attachments.count == 1, let attachment = attachments.first else {
+            return String(localized: "\(attachments.count) attachments")
+        }
+
+        if attachment.content_type.hasPrefix("image/") {
+            return String(localized: "Photo")
+        }
+        if attachment.content_type.hasPrefix("video/") {
+            return String(localized: "Video")
+        }
+        if attachment.content_type.hasPrefix("audio/") {
+            return String(localized: "Audio")
+        }
+        return attachment.filename
     }
     
     var body: some View {
@@ -137,7 +154,7 @@ struct InnerMessageReplyView: View {
                             
                             HStack(spacing: .spacing2){
                                 
-                                PeptideText(text: "Tap to see  attachment",
+                                PeptideText(text: attachmentSummary(message.attachments ?? []),
                                             font: .peptideFootnote,
                                             textColor: .textGray06,
                                             lineLimit: 1)
@@ -200,4 +217,3 @@ struct InnerMessageReplyView: View {
         }
     }
 }
-

--- a/Revolt/Components/MessageRenderer/MessageView.swift
+++ b/Revolt/Components/MessageRenderer/MessageView.swift
@@ -100,12 +100,12 @@ struct MessageView: View {
     private var authorBadge: (text: String, color: Color)? {
         if viewModel.author.bot != nil {
             return viewModel.message.masquerade == nil
-                ? (String(localized: "BOT"), .bgPurple10)
-                : (String(localized: "BRIDGE"), .bgRed07)
+                ? (String(localized: "BOT"), .bgPurple10.opacity(0.8))
+                : (String(localized: "BRIDGE"), .bgGray10.opacity(0.85))
         }
 
         if isNewAccount(viewModel.author) {
-            return (String(localized: "NEW"), .bgGreen07)
+            return (String(localized: "NEW"), .bgGreen07.opacity(0.75))
         }
 
         return nil
@@ -275,7 +275,7 @@ struct MessageView: View {
                                         
                                         Text(formattedMessageDate(from: createdAt(id: viewModel.message.id)))
                                             .font(.peptideFootnoteFont)
-                                            .foregroundStyle(.textGray06)
+                                            .foregroundStyle(.textGray04)
                                             .lineLimit(1)
                                     }
                                     

--- a/Revolt/Extensions/StringExtensions.swift
+++ b/Revolt/Extensions/StringExtensions.swift
@@ -1,42 +1,45 @@
 import Foundation
 
 extension String {
-    func convertMentionsToUsernames(viewState: ViewState) -> String {
+    func replacingUserMentionTokens(
+        fallback: String = "@unknown-user",
+        usernameForUserId: (String) -> String?
+    ) -> String {
         var result = self
-        
-        // Regular expression to match mention format: <@user_id>
-        let pattern = "<@([A-Z0-9]+)>"
-        
-        do {
-            let regex = try NSRegularExpression(pattern: pattern)
-            let range = NSRange(location: 0, length: result.utf16.count)
-            
-            // Find all matches
-            let matches = regex.matches(in: result, range: range)
-            
-            // Process matches in reverse to avoid index issues
-            for match in matches.reversed() {
-                if let userIdRange = Range(match.range(at: 1), in: result) {
-                    let userId = String(result[userIdRange])
-                    
-                    // Try to find user in viewState
-                    if let user = viewState.users[userId] {
-                        // Replace the mention with username
-                        let mentionRange = Range(match.range, in: result)!
-                        let username = user.display_name ?? user.username
-                        result.replaceSubrange(mentionRange, with: "@\(username)")
-                    }
-                }
-            }
-        } catch {
-            print("DEBUG: Error creating regex: \(error)")
+        guard let regex = try? NSRegularExpression(pattern: "<@([A-Za-z0-9]+)>") else {
+            return result
         }
-        
+
+        let matches = regex.matches(
+            in: result,
+            range: NSRange(location: 0, length: result.utf16.count)
+        )
+
+        for match in matches.reversed() {
+            guard let idRange = Range(match.range(at: 1), in: result),
+                  let mentionRange = Range(match.range, in: result) else {
+                continue
+            }
+
+            let userId = String(result[idRange])
+            let replacement = usernameForUserId(userId).map { "@\($0)" } ?? fallback
+            result.replaceSubrange(mentionRange, with: replacement)
+        }
+
         return result
+    }
+
+    func convertMentionsToUsernames(viewState: ViewState) -> String {
+        replacingUserMentionTokens { userId in
+            guard let user = viewState.users[userId] ?? viewState.allEventUsers[userId] else {
+                return nil
+            }
+            return user.display_name ?? user.username
+        }
     }
     
     func containsMention() -> Bool {
-        let pattern = "<@([A-Z0-9]+)>"
+        let pattern = "<@([A-Za-z0-9]+)>"
         do {
             let regex = try NSRegularExpression(pattern: pattern)
             let range = NSRange(location: 0, length: self.utf16.count)
@@ -46,4 +49,4 @@ extension String {
             return false
         }
     }
-} 
+}

--- a/Revolt/Pages/Channel/Messagable/Controllers/FullScreenImageViewController.swift
+++ b/Revolt/Pages/Channel/Messagable/Controllers/FullScreenImageViewController.swift
@@ -8,33 +8,81 @@ import UIKit
 import Photos
 import Kingfisher
 
+struct FullScreenImageItem {
+    let previewImage: UIImage?
+    let originalImageURL: URL?
+    let sessionToken: String?
+}
+
+enum FullScreenImageGalleryNavigation {
+    static func destinationIndex(currentIndex: Int, itemCount: Int, step: Int) -> Int? {
+        guard itemCount > 1, abs(step) == 1 else { return nil }
+        let destination = currentIndex + step
+        return (0..<itemCount).contains(destination) ? destination : nil
+    }
+
+    static func positionText(currentIndex: Int, itemCount: Int) -> String? {
+        guard itemCount > 1, (0..<itemCount).contains(currentIndex) else { return nil }
+        return "\(currentIndex + 1) of \(itemCount)"
+    }
+}
+
 // MARK: - FullScreenImageViewController
-class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
+class FullScreenImageViewController: UIViewController, UIScrollViewDelegate, UIGestureRecognizerDelegate {
     private let scrollView = UIScrollView()
     private let imageView = UIImageView()
     private let closeButton = UIButton(type: .system)
     private let downloadButton = UIButton(type: .system)
     private let buttonStackView = UIStackView()
+    private let positionLabel = UILabel()
+    private let items: [FullScreenImageItem]
+    private var currentIndex: Int
+    private var originalImageDataByIndex: [Int: Data] = [:]
+    private var originalImageDataTask: URLSessionDataTask?
+    private var isTransitioningBetweenImages = false
+    private lazy var swipeLeftGesture = UISwipeGestureRecognizer(
+        target: self,
+        action: #selector(handleGallerySwipe(_:))
+    )
+    private lazy var swipeRightGesture = UISwipeGestureRecognizer(
+        target: self,
+        action: #selector(handleGallerySwipe(_:))
+    )
     
     // Zoom properties
     private var minZoomScale: CGFloat = 1.0
     private var maxZoomScale: CGFloat = 5.0
     private var hasSetInitialZoom = false
-    private let originalImageURL: URL?
-    private let sessionToken: String?
-    private var originalImageData: Data?
-    
-    init(image: UIImage, originalImageURL: URL?, sessionToken: String?) {
-        self.originalImageURL = originalImageURL
-        self.sessionToken = sessionToken
+
+    init(items: [FullScreenImageItem], initialIndex: Int) {
+        precondition(!items.isEmpty, "Full-screen image gallery requires at least one item")
+        self.items = items
+        self.currentIndex = min(max(0, initialIndex), items.count - 1)
         super.init(nibName: nil, bundle: nil)
-        imageView.image = image
+        imageView.image = items[self.currentIndex].previewImage
         modalPresentationStyle = .fullScreen
         modalTransitionStyle = .crossDissolve
+    }
+
+    convenience init(image: UIImage, originalImageURL: URL?, sessionToken: String?) {
+        self.init(
+            items: [
+                FullScreenImageItem(
+                    previewImage: image,
+                    originalImageURL: originalImageURL,
+                    sessionToken: sessionToken
+                )
+            ],
+            initialIndex: 0
+        )
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        originalImageDataTask?.cancel()
     }
     
     override func viewDidLoad() {
@@ -45,11 +93,14 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
         setupImageView()
         setupButtons()
         setupGestures()
-        loadOriginalImageIfAvailable()
+        displayCurrentItem()
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        if !hasSetInitialZoom {
+            setInitialZoomScale()
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -66,6 +117,7 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
         scrollView.decelerationRate = UIScrollView.DecelerationRate.fast
         scrollView.bouncesZoom = true
         scrollView.bounces = true
+        scrollView.alwaysBounceHorizontal = true
         scrollView.contentInsetAdjustmentBehavior = .never
         
         view.addSubview(scrollView)
@@ -114,6 +166,16 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
         buttonStackView.addArrangedSubview(closeButton)
         
         view.addSubview(buttonStackView)
+
+        positionLabel.translatesAutoresizingMaskIntoConstraints = false
+        positionLabel.font = UIFont.systemFont(ofSize: 13, weight: .semibold)
+        positionLabel.textColor = .white
+        positionLabel.textAlignment = .center
+        positionLabel.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        positionLabel.layer.cornerRadius = 14
+        positionLabel.layer.masksToBounds = true
+        positionLabel.isAccessibilityElement = true
+        view.addSubview(positionLabel)
         
         NSLayoutConstraint.activate([
             // Button size constraints
@@ -124,7 +186,12 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
             
             // Stack view position
             buttonStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
-            buttonStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16)
+            buttonStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+
+            positionLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            positionLabel.centerYAnchor.constraint(equalTo: buttonStackView.centerYAnchor),
+            positionLabel.heightAnchor.constraint(equalToConstant: 28),
+            positionLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 54)
         ])
     }
     
@@ -141,17 +208,40 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
         
         // Make sure single tap doesn't interfere with double tap
         singleTapGesture.require(toFail: doubleTapGesture)
+
+        swipeLeftGesture.direction = .left
+        swipeRightGesture.direction = .right
+        swipeLeftGesture.delegate = self
+        swipeRightGesture.delegate = self
+        scrollView.addGestureRecognizer(swipeLeftGesture)
+        scrollView.addGestureRecognizer(swipeRightGesture)
+
+        // Give gallery swipes first chance at the fitted scale. When zoomed in,
+        // the swipe delegates decline and UIScrollView keeps normal image panning.
+        scrollView.panGestureRecognizer.require(toFail: swipeLeftGesture)
+        scrollView.panGestureRecognizer.require(toFail: swipeRightGesture)
+
     }
     
     private func setInitialZoomScale() {
         guard let image = imageView.image else { return }
-        hasSetInitialZoom = true
         
         let scrollViewSize = scrollView.bounds.size
         guard scrollViewSize.width > 0 && scrollViewSize.height > 0 else { return }
         
         let imageSize = image.size
         guard imageSize.width > 0 && imageSize.height > 0 else { return }
+
+        hasSetInitialZoom = true
+
+        // Clear the previous item's zoom transform before changing the image view's
+        // geometry. Without this reset, assigning a new frame while UIScrollView is
+        // still scaled can leave the next image thumbnail-sized or off screen.
+        scrollView.minimumZoomScale = 0.01
+        scrollView.maximumZoomScale = max(scrollView.maximumZoomScale, 1)
+        scrollView.setZoomScale(1, animated: false)
+        scrollView.contentInset = .zero
+        scrollView.contentOffset = .zero
         
         // Set imageView frame to match image size
         imageView.frame = CGRect(origin: .zero, size: imageSize)
@@ -191,11 +281,136 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
             right: horizontalInset
         )
     }
-    
+
+    private func displayCurrentItem() {
+        imageView.kf.cancelDownloadTask()
+        originalImageDataTask?.cancel()
+        originalImageDataTask = nil
+
+        hasSetInitialZoom = false
+        scrollView.minimumZoomScale = 0.01
+        scrollView.maximumZoomScale = max(scrollView.maximumZoomScale, 1)
+        scrollView.setZoomScale(1, animated: false)
+        scrollView.contentInset = .zero
+
+        let item = items[currentIndex]
+        imageView.image = item.previewImage ?? UIImage(systemName: "photo")
+        imageView.alpha = 1
+        imageView.accessibilityLabel = "Image \(currentIndex + 1) of \(items.count)"
+
+        positionLabel.text = FullScreenImageGalleryNavigation.positionText(
+            currentIndex: currentIndex,
+            itemCount: items.count
+        )
+        positionLabel.accessibilityLabel = positionLabel.text
+        positionLabel.isHidden = items.count <= 1
+
+        view.layoutIfNeeded()
+        setInitialZoomScale()
+        loadOriginalImageIfAvailable()
+    }
+
+    @objc private func handleGallerySwipe(_ gesture: UISwipeGestureRecognizer) {
+        let step = gesture.direction == .left ? 1 : -1
+        guard let destination = FullScreenImageGalleryNavigation.destinationIndex(
+            currentIndex: currentIndex,
+            itemCount: items.count,
+            step: step
+        ) else {
+            return
+        }
+
+        transitionToImage(at: destination, step: step)
+    }
+
+    private func transitionToImage(at requestedIndex: Int, step: Int) {
+        guard !isTransitioningBetweenImages else { return }
+        guard let destination = FullScreenImageGalleryNavigation.destinationIndex(
+            currentIndex: currentIndex,
+            itemCount: items.count,
+            step: step
+        ), destination == requestedIndex else {
+            restoreGalleryPosition()
+            return
+        }
+
+        let travelDirection: CGFloat = step > 0 ? -1 : 1
+        isTransitioningBetweenImages = true
+        view.isUserInteractionEnabled = false
+
+        UIView.animate(
+            withDuration: 0.14,
+            delay: 0,
+            options: [.curveEaseIn],
+            animations: {
+                self.scrollView.transform = CGAffineTransform(
+                    translationX: travelDirection * self.view.bounds.width * 0.22,
+                    y: 0
+                )
+                self.scrollView.alpha = 0
+            },
+            completion: { _ in
+                self.currentIndex = destination
+                self.scrollView.transform = CGAffineTransform(
+                    translationX: -travelDirection * self.view.bounds.width * 0.22,
+                    y: 0
+                )
+                self.displayCurrentItem()
+                self.scrollView.alpha = 0
+
+                UIView.animate(
+                    withDuration: 0.2,
+                    delay: 0,
+                    options: [.curveEaseOut],
+                    animations: {
+                        self.scrollView.transform = .identity
+                        self.scrollView.alpha = 1
+                    },
+                    completion: { _ in
+                        self.isTransitioningBetweenImages = false
+                        self.view.isUserInteractionEnabled = true
+                    }
+                )
+            }
+        )
+    }
+
+    private func restoreGalleryPosition() {
+        UIView.animate(
+            withDuration: 0.18,
+            delay: 0,
+            options: [.curveEaseOut],
+            animations: {
+                self.scrollView.transform = .identity
+            }
+        )
+    }
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer === swipeLeftGesture || gestureRecognizer === swipeRightGesture else {
+            return true
+        }
+
+        guard !isTransitioningBetweenImages,
+              items.count > 1,
+              abs(scrollView.zoomScale - minZoomScale) < 0.01 else {
+            return false
+        }
+
+        let step = gestureRecognizer === swipeLeftGesture ? 1 : -1
+        return FullScreenImageGalleryNavigation.destinationIndex(
+            currentIndex: currentIndex,
+            itemCount: items.count,
+            step: step
+        ) != nil
+    }
+
     @objc private func handleSingleTap() {
         // Toggle buttons visibility
         UIView.animate(withDuration: 0.3) {
-            self.buttonStackView.alpha = self.buttonStackView.alpha == 0 ? 1 : 0
+            let targetAlpha: CGFloat = self.buttonStackView.alpha == 0 ? 1 : 0
+            self.buttonStackView.alpha = targetAlpha
+            self.positionLabel.alpha = targetAlpha
         }
     }
     
@@ -221,7 +436,7 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
     
     @objc private func downloadImage() {
         // Prefer original bytes from network for best quality.
-        if let data = originalImageData {
+        if let data = originalImageDataByIndex[currentIndex] {
             saveImageDataToPhotoLibrary(data)
             return
         }
@@ -242,15 +457,17 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
     }
 
     private func loadOriginalImageIfAvailable() {
-        guard let originalImageURL else { return }
-        fetchOriginalImageData(from: originalImageURL)
+        let loadingIndex = currentIndex
+        let item = items[loadingIndex]
+        guard let originalImageURL = item.originalImageURL else { return }
+        fetchOriginalImageData(from: originalImageURL, itemIndex: loadingIndex)
 
         var options: KingfisherOptionsInfo = [
             .cacheOriginalImage,
             .transition(.fade(0.2))
         ]
 
-        if let token = sessionToken, !token.isEmpty {
+        if let token = item.sessionToken, !token.isEmpty {
             let modifier = AnyModifier { request in
                 var req = request
                 req.setValue(token, forHTTPHeaderField: "x-session-token")
@@ -265,29 +482,35 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
             options: options
         ) { [weak self] result in
             guard let self = self else { return }
+            guard self.currentIndex == loadingIndex else { return }
             if case .success(let value) = result {
                 // Keep fallback data even when raw-bytes fetch fails.
-                if self.originalImageData == nil {
-                    self.originalImageData = value.image.pngData() ?? value.image.jpegData(compressionQuality: 1.0)
+                if self.originalImageDataByIndex[loadingIndex] == nil {
+                    self.originalImageDataByIndex[loadingIndex] = value.image.pngData()
+                        ?? value.image.jpegData(compressionQuality: 1.0)
                 }
+                self.hasSetInitialZoom = false
                 self.setInitialZoomScale()
             }
         }
     }
 
-    private func fetchOriginalImageData(from url: URL) {
+    private func fetchOriginalImageData(from url: URL, itemIndex: Int) {
         var request = URLRequest(url: url)
-        if let token = sessionToken, !token.isEmpty {
+        if let token = items[itemIndex].sessionToken, !token.isEmpty {
             request.setValue(token, forHTTPHeaderField: "x-session-token")
         }
 
-        URLSession.shared.dataTask(with: request) { [weak self] data, response, _ in
-            guard let self = self, let data = data, !data.isEmpty else { return }
+        originalImageDataTask = URLSession.shared.dataTask(with: request) { [weak self] data, response, _ in
+            guard let data = data, !data.isEmpty else { return }
             if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
                 return
             }
-            self.originalImageData = data
-        }.resume()
+            DispatchQueue.main.async { [weak self] in
+                self?.originalImageDataByIndex[itemIndex] = data
+            }
+        }
+        originalImageDataTask?.resume()
     }
     
     private func saveImageToPhotoLibrary(_ image: UIImage) {
@@ -432,6 +655,32 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
     
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
         centerImageView()
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        guard !isTransitioningBetweenImages,
+              items.count > 1,
+              abs(scrollView.zoomScale - minZoomScale) < 0.01 else {
+            return
+        }
+
+        let translation = scrollView.panGestureRecognizer.translation(in: view)
+        let velocity = scrollView.panGestureRecognizer.velocity(in: view)
+        guard abs(translation.x) > abs(translation.y),
+              abs(translation.x) > 60 || abs(velocity.x) > 500 else {
+            return
+        }
+
+        let step = translation.x < 0 ? 1 : -1
+        guard let destination = FullScreenImageGalleryNavigation.destinationIndex(
+            currentIndex: currentIndex,
+            itemCount: items.count,
+            step: step
+        ) else {
+            return
+        }
+
+        transitionToImage(at: destination, step: step)
     }
     
     func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {

--- a/Revolt/Pages/Channel/Messagable/DataSources/MessageTableViewDataSource.swift
+++ b/Revolt/Pages/Channel/Messagable/DataSources/MessageTableViewDataSource.swift
@@ -96,12 +96,8 @@ class MessageTableViewDataSource: NSObject, UITableViewDataSource {
                     viewController?.handleMessageAction(action, message: message)
                 }
 
-                cell.onImageTapped = { [weak viewController] image, originalURL, sessionToken in
-                    viewController?.showFullScreenImage(
-                        image,
-                        originalImageURL: originalURL,
-                        sessionToken: sessionToken
-                    )
+                cell.onImageTapped = { [weak viewController] items, initialIndex in
+                    viewController?.showFullScreenImages(items, initialIndex: initialIndex)
                 }
 
                 if let viewController = viewController {
@@ -229,12 +225,8 @@ class LocalMessagesDataSource: NSObject, UITableViewDataSource {
                     viewControllerRef?.handleMessageAction(action, message: message)
                 }
 
-                cell.onImageTapped = { [weak viewControllerRef] image, originalURL, sessionToken in
-                    viewControllerRef?.showFullScreenImage(
-                        image,
-                        originalImageURL: originalURL,
-                        sessionToken: sessionToken
-                    )
+                cell.onImageTapped = { [weak viewControllerRef] items, initialIndex in
+                    viewControllerRef?.showFullScreenImages(items, initialIndex: initialIndex)
                 }
 
                 // Present user sheet on avatar tap

--- a/Revolt/Pages/Channel/Messagable/Mention/MentionInputView.swift
+++ b/Revolt/Pages/Channel/Messagable/Mention/MentionInputView.swift
@@ -50,17 +50,23 @@ private final class PassthroughMentionWindow: UIWindow {
 
 protocol MentionInputViewDelegate: AnyObject {
     func mentionInputView(_ mentionView: MentionInputView, didSelectUser user: User, member: Member?)
+    func mentionInputViewDidSelectEveryone(_ mentionView: MentionInputView)
     func mentionInputViewDidDismiss(_ mentionView: MentionInputView)
 }
 
 class MentionInputView: UIView {
+    private enum Suggestion {
+        case everyone
+        case user(User, Member?)
+    }
+
     // MARK: - Properties
     private let tableView = UITableView()
     private let emptyStateLabel = UILabel()
     private let containerView = UIView()
     
     private var users: [(User, Member?)] = []
-    private var filteredUsers: [(User, Member?)] = []
+    private var filteredSuggestions: [Suggestion] = []
     private var searchText: String = ""
     
     weak var delegate: MentionInputViewDelegate?
@@ -125,7 +131,7 @@ class MentionInputView: UIView {
         // Reset state when channel changes
         usersLoaded = false
         users.removeAll()
-        filteredUsers.removeAll()
+        filteredSuggestions.removeAll()
         searchText = ""
         isDismissed = true
         fullRosterTask?.cancel()
@@ -156,7 +162,7 @@ class MentionInputView: UIView {
         searchWorkItem = nil
         searchText = ""
         isDismissed = true
-        filteredUsers.removeAll()
+        filteredSuggestions.removeAll()
         tableView.reloadData()
         hidePopup(animated: animated)
     }
@@ -192,7 +198,7 @@ class MentionInputView: UIView {
     
     private func showAsPopup() {
         guard !isDismissed else { return }
-        guard filteredUsers.count > 0 else { 
+        guard !filteredSuggestions.isEmpty else {
             hidePopup()
             return 
         }
@@ -236,7 +242,7 @@ class MentionInputView: UIView {
         containerViewController.view.addSubview(self)
         
         // Calculate better height: maximum 8 users displayed for better UX  
-        let maxVisibleUsers = min(filteredUsers.count, 8)
+        let maxVisibleUsers = min(filteredSuggestions.count, 8)
         let minHeight: CGFloat = 64 // Minimum height for 1 user
         let mentionHeight: CGFloat = max(minHeight, CGFloat(maxVisibleUsers * 48) + 16) // 8px padding top and bottom
         let margin: CGFloat = 20
@@ -288,7 +294,7 @@ class MentionInputView: UIView {
         guard let heightConstraint = heightConstraint else { return }
         
         // Calculate new height based on current filtered users
-        let maxVisibleUsers = min(filteredUsers.count, 8)
+        let maxVisibleUsers = min(filteredSuggestions.count, 8)
         let minHeight: CGFloat = 64 // Minimum height for 1 user
         let newHeight: CGFloat = max(minHeight, CGFloat(maxVisibleUsers * 48) + 16) // 8px padding top and bottom
         
@@ -352,7 +358,7 @@ class MentionInputView: UIView {
         currentChannel = nil
         currentServer = nil
         users.removeAll()
-        filteredUsers.removeAll()
+        filteredSuggestions.removeAll()
         isDismissed = true
     }
     
@@ -576,6 +582,12 @@ class MentionInputView: UIView {
     }
     
     private func filterUsers() {
+        let includeEveryone = MentionInputUtilities.shouldIncludeEveryone(
+            searchText: searchText,
+            canMentionEveryone: canMentionEveryone
+        )
+
+        let filteredUsers: [(User, Member?)]
         if searchText.isEmpty {
             filteredUsers = users
         } else {
@@ -626,8 +638,10 @@ class MentionInputView: UIView {
             
             // Combine priority matches first, then secondary matches
             filteredUsers = priorityMatches + secondaryMatches
-            
         }
+
+        filteredSuggestions = (includeEveryone ? [.everyone] : [])
+            + filteredUsers.map { .user($0.0, $0.1) }
         
         DispatchQueue.main.async {
             guard !self.isDismissed else { return }
@@ -635,13 +649,13 @@ class MentionInputView: UIView {
             self.updateEmptyState()
             
             // Configure bounce behavior based on number of users
-            let contentHeight = CGFloat(self.filteredUsers.count * 48)
+            let contentHeight = CGFloat(self.filteredSuggestions.count * 48)
             let tableHeight = self.tableView.frame.height
             self.tableView.alwaysBounceVertical = contentHeight > tableHeight
             self.tableView.bounces = contentHeight > tableHeight
             
             // Show or hide popup based on filtered results
-            if !self.filteredUsers.isEmpty {
+            if !self.filteredSuggestions.isEmpty {
                 self.showAsPopup()
             } else {
                 self.hidePopup()
@@ -651,8 +665,33 @@ class MentionInputView: UIView {
     
     private func updateEmptyState() {
         DispatchQueue.main.async {
-            self.emptyStateLabel.isHidden = !self.filteredUsers.isEmpty
-            self.tableView.isHidden = self.filteredUsers.isEmpty
+            self.emptyStateLabel.isHidden = !self.filteredSuggestions.isEmpty
+            self.tableView.isHidden = self.filteredSuggestions.isEmpty
+        }
+    }
+
+    private var canMentionEveryone: Bool {
+        guard let channel = currentChannel else { return false }
+
+        switch channel {
+        case .group_dm_channel:
+            return true
+        case .text_channel:
+            guard let server = currentServer,
+                  let currentUser = viewState.currentUser else {
+                return false
+            }
+            let member = viewState.members[server.id]?[currentUser.id]
+            let permissions = resolveChannelPermissions(
+                from: currentUser,
+                targettingUser: currentUser,
+                targettingMember: member,
+                channel: channel,
+                server: server
+            )
+            return permissions.contains(.mentionEveryone)
+        default:
+            return false
         }
     }
     
@@ -745,19 +784,24 @@ class MentionInputView: UIView {
 // MARK: - UITableViewDelegate & UITableViewDataSource
 extension MentionInputView: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return filteredUsers.count
+        return filteredSuggestions.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "MentionUserCell", for: indexPath) as? MentionUserCell,
-              indexPath.row < filteredUsers.count else {
+              indexPath.row < filteredSuggestions.count else {
             return UITableViewCell()
         }
-        
-        let (user, member) = filteredUsers[indexPath.row]
-        cell.configure(with: user, member: member, viewState: viewState) { [weak self] selectedUser, selectedMember in
-            // print("DEBUG: Cell onSelect called for user: \(selectedUser.username)")
-            self?.tableView(tableView, didSelectRowAt: indexPath)
+
+        switch filteredSuggestions[indexPath.row] {
+        case .everyone:
+            cell.configureEveryone { [weak self] in
+                self?.tableView(tableView, didSelectRowAt: indexPath)
+            }
+        case .user(let user, let member):
+            cell.configure(with: user, member: member, viewState: viewState) { [weak self] _, _ in
+                self?.tableView(tableView, didSelectRowAt: indexPath)
+            }
         }
         return cell
     }
@@ -779,8 +823,8 @@ extension MentionInputView: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         
-        guard indexPath.row < filteredUsers.count else { return }
-        let (user, member) = filteredUsers[indexPath.row]
+        guard indexPath.row < filteredSuggestions.count else { return }
+        let suggestion = filteredSuggestions[indexPath.row]
         
         // print("DEBUG: ==========================================")
         // print("DEBUG: USER SELECTED FROM MENTION LIST")
@@ -799,7 +843,12 @@ extension MentionInputView: UITableViewDelegate, UITableViewDataSource {
         // print("DEBUG: User selected from popup: \(user.username)")
         
         // DIRECT IMPLEMENTATION: Insert the mention text directly
-        insertMentionText(for: user, member: member)
+        switch suggestion {
+        case .everyone:
+            delegate?.mentionInputViewDidSelectEveryone(self)
+        case .user(let user, let member):
+            insertMentionText(for: user, member: member)
+        }
     }
     
     // Recursive function to find a textView
@@ -829,6 +878,7 @@ class MentionUserCell: UITableViewCell {
     private var member: Member?
     private var viewState: ViewState?
     private var onSelect: ((User, Member?) -> Void)?
+    private var onSelectEveryone: (() -> Void)?
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -892,10 +942,26 @@ class MentionUserCell: UITableViewCell {
     }
     
     @objc private func handleTap() {
-                    // print("DEBUG: Cell tapped for user: \(user?.username ?? "unknown")")
+        if let onSelectEveryone {
+            onSelectEveryone()
+            return
+        }
         if let user = user {
             onSelect?(user, member)
         }
+    }
+
+    func configureEveryone(onSelect: @escaping () -> Void) {
+        user = nil
+        member = nil
+        viewState = nil
+        self.onSelect = nil
+        onSelectEveryone = onSelect
+        nameLabel.text = "everyone"
+        usernameLabel.text = "Notify everyone in this channel"
+        avatarImageView.kf.cancelDownloadTask()
+        avatarImageView.image = UIImage(systemName: "person.3.fill")
+        avatarImageView.tintColor = UIColor(named: "iconYellow07") ?? UIColor.systemYellow
     }
     
     func configure(with user: User, member: Member?, viewState: ViewState, onSelect: @escaping (User, Member?) -> Void) {
@@ -903,6 +969,7 @@ class MentionUserCell: UITableViewCell {
         self.member = member
         self.viewState = viewState
         self.onSelect = onSelect
+        onSelectEveryone = nil
         
         // Set username and display name
         nameLabel.text = member?.nickname ?? user.display_name ?? user.username

--- a/Revolt/Pages/Channel/Messagable/Mention/MentionInputView.swift
+++ b/Revolt/Pages/Channel/Messagable/Mention/MentionInputView.swift
@@ -671,28 +671,11 @@ class MentionInputView: UIView {
     }
 
     private var canMentionEveryone: Bool {
-        guard let channel = currentChannel else { return false }
-
-        switch channel {
-        case .group_dm_channel:
-            return true
-        case .text_channel:
-            guard let server = currentServer,
-                  let currentUser = viewState.currentUser else {
-                return false
-            }
-            let member = viewState.members[server.id]?[currentUser.id]
-            let permissions = resolveChannelPermissions(
-                from: currentUser,
-                targettingUser: currentUser,
-                targettingMember: member,
-                channel: channel,
-                server: server
-            )
-            return permissions.contains(.mentionEveryone)
-        default:
-            return false
-        }
+        MentionInputUtilities.canMentionEveryone(
+            in: currentChannel,
+            server: currentServer,
+            viewState: viewState
+        )
     }
     
     private func insertMentionText(for user: User, member: Member?) {

--- a/Revolt/Pages/Channel/Messagable/MessageableChannelViewController.swift
+++ b/Revolt/Pages/Channel/Messagable/MessageableChannelViewController.swift
@@ -1608,11 +1608,11 @@ class MessageableChannelViewController: UIViewController, UITextFieldDelegate,
     }
 
     // MARK: - Image Handling
-    func showFullScreenImage(_ image: UIImage, originalImageURL: URL?, sessionToken: String?) {
+    func showFullScreenImages(_ items: [FullScreenImageItem], initialIndex: Int) {
+        guard !items.isEmpty else { return }
         let imageViewController = FullScreenImageViewController(
-            image: image,
-            originalImageURL: originalImageURL,
-            sessionToken: sessionToken
+            items: items,
+            initialIndex: initialIndex
         )
         imageViewController.modalPresentationStyle = .overFullScreen
         present(imageViewController, animated: true, completion: nil)
@@ -2052,12 +2052,8 @@ class MessageableChannelViewController: UIViewController, UITextFieldDelegate,
                     viewController?.handleMessageAction(action, message: message)
                 }
 
-                messageCell.onImageTapped = { [weak viewController = viewControllerRef] image, originalURL, sessionToken in
-                    viewController?.showFullScreenImage(
-                        image,
-                        originalImageURL: originalURL,
-                        sessionToken: sessionToken
-                    )
+                messageCell.onImageTapped = { [weak viewController = viewControllerRef] items, initialIndex in
+                    viewController?.showFullScreenImages(items, initialIndex: initialIndex)
                 }
 
                 messageCell.onAvatarTap = { [weak viewModel = viewModelRef] in
@@ -3456,7 +3452,10 @@ class MessageableChannelViewController: UIViewController, UITextFieldDelegate,
 extension MessageCell {
     @objc func handleImageTap(_ gesture: UITapGestureRecognizer) {
         if let imageView = gesture.view as? UIImageView, let image = imageView.image {
-            onImageTapped?(image, nil, nil)
+            onImageTapped?(
+                [FullScreenImageItem(previewImage: image, originalImageURL: nil, sessionToken: nil)],
+                0
+            )
         }
     }
 }

--- a/Revolt/Pages/Channel/Messagable/Utils/MarkdownProcessor.swift
+++ b/Revolt/Pages/Channel/Messagable/Utils/MarkdownProcessor.swift
@@ -27,7 +27,7 @@ func processMarkdownOptimized(_ text: String) -> NSAttributedString {
 
     // Apply default font and color
     mutableAttributedString.addAttributes([
-        .font: UIFont.systemFont(ofSize: 15, weight: .light),
+        .font: UIFont.systemFont(ofSize: 15, weight: .regular),
         .foregroundColor: UIColor.textDefaultGray01
     ], range: NSRange(location: 0, length: mutableAttributedString.length))
 
@@ -649,4 +649,3 @@ func createHeaderParagraphStyle() -> NSParagraphStyle {
     paragraphStyle.headIndent = 0.0 // No indentation for subsequent lines
     return paragraphStyle
 }
-

--- a/Revolt/Pages/Channel/Messagable/Views/LinkPreviewView.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/LinkPreviewView.swift
@@ -11,7 +11,7 @@ import Kingfisher
 import WebKit
 
 /// A UIView that renders different types of message embeds, such as website previews, images, videos, and text embeds.
-class LinkPreviewView: UIView {
+class LinkPreviewView: UIView, WKNavigationDelegate {
     private static let fallbackMediaAspectRatio: CGFloat = 16.0 / 9.0
     
     // MARK: - UI Components
@@ -27,6 +27,7 @@ class LinkPreviewView: UIView {
     // Content components
     private let descriptionLabel = UILabel()
     private let previewImageView = UIImageView()
+    private let mediaStatusLabel = UILabel()
     private let videoView = UIView()
     private var webView: WKWebView?
     
@@ -103,6 +104,11 @@ class LinkPreviewView: UIView {
         previewImageView.clipsToBounds = true
         previewImageView.layer.cornerRadius = 6
         previewImageView.isHidden = true
+
+        mediaStatusLabel.translatesAutoresizingMaskIntoConstraints = false
+        mediaStatusLabel.font = UIFont.systemFont(ofSize: 13, weight: .medium)
+        mediaStatusLabel.textColor = UIColor(named: "textGray06") ?? .secondaryLabel
+        mediaStatusLabel.numberOfLines = 1
         
         // Setup constraints
         setupConstraints()
@@ -129,8 +135,8 @@ class LinkPreviewView: UIView {
             contentStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -8),
             
             // Icon image view
-            iconImageView.widthAnchor.constraint(equalToConstant: 64),
-            iconImageView.heightAnchor.constraint(equalToConstant: 64),
+            iconImageView.widthAnchor.constraint(equalToConstant: 20),
+            iconImageView.heightAnchor.constraint(equalToConstant: 20),
             
             // Preview image view
             previewImageView.heightAnchor.constraint(equalToConstant: 200),
@@ -180,9 +186,25 @@ class LinkPreviewView: UIView {
         previewImageView.image = nil
         previewImageView.isHidden = true
         iconImageView.image = nil
+        webView?.stopLoading()
+        webView?.navigationDelegate = nil
         webView?.removeFromSuperview()
         webView = nil
+        mediaStatusLabel.text = nil
         isHidden = false
+    }
+
+    private func showMediaStatus(_ text: String) {
+        mediaStatusLabel.text = text
+        if mediaStatusLabel.superview == nil {
+            contentStackView.addArrangedSubview(mediaStatusLabel)
+        }
+    }
+
+    private func hideMediaStatus() {
+        contentStackView.removeArrangedSubview(mediaStatusLabel)
+        mediaStatusLabel.removeFromSuperview()
+        mediaStatusLabel.text = nil
     }
     
     // MARK: - Website Embed Configuration
@@ -247,9 +269,12 @@ class LinkPreviewView: UIView {
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.isOpaque = false
         webView.backgroundColor = .clear
+        webView.navigationDelegate = self
+        webView.isHidden = true
         
         let aspectRatio = getSpecialEmbedAspectRatio(special, websiteEmbed: websiteEmbed)
         
+        showMediaStatus("Loading preview…")
         contentStackView.addArrangedSubview(webView)
         
         NSLayoutConstraint.activate([
@@ -265,6 +290,32 @@ class LinkPreviewView: UIView {
         self.webView = webView
         
         return true
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard webView === self.webView else { return }
+        hideMediaStatus()
+        webView.isHidden = false
+        onAsyncLayoutAffectingContentLoaded?()
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        guard webView === self.webView else { return }
+        webView.removeFromSuperview()
+        showMediaStatus("Preview unavailable")
+        onAsyncLayoutAffectingContentLoaded?()
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        self.webView(webView, didFail: navigation, withError: error)
     }
     
     private func getSpecialEmbedUrl(_ websiteEmbed: WebsiteEmbed, special: WebsiteSpecial) -> URL? {
@@ -340,16 +391,21 @@ class LinkPreviewView: UIView {
     private func configureImagePreview(_ image: JanuaryImage) -> Bool {
         guard let url = URL(string: image.url) else { return false }
         
-        previewImageView.isHidden = false
+        showMediaStatus("Loading preview…")
+        previewImageView.isHidden = true
         previewImageView.kf.setImage(with: url) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success:
+                self.hideMediaStatus()
+                self.previewImageView.isHidden = false
                 self.setNeedsLayout()
                 self.layoutIfNeeded()
                 self.onAsyncLayoutAffectingContentLoaded?()
-            case .failure(let error):
-                _ = error
+            case .failure:
+                self.previewImageView.isHidden = true
+                self.showMediaStatus("Preview unavailable")
+                self.onAsyncLayoutAffectingContentLoaded?()
             }
         }
         contentStackView.addArrangedSubview(previewImageView)
@@ -374,10 +430,22 @@ class LinkPreviewView: UIView {
     private func configureVideoPreview(_ video: JanuaryVideo) -> Bool {
         guard let url = URL(string: video.url) else { return false }
         
-        previewImageView.isHidden = false
+        showMediaStatus("Loading preview…")
+        previewImageView.isHidden = true
         // For video, you might want to show a thumbnail or use AVPlayerLayer
         // For now, we'll treat it like an image
-        previewImageView.kf.setImage(with: url)
+        previewImageView.kf.setImage(with: url) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success:
+                self.hideMediaStatus()
+                self.previewImageView.isHidden = false
+            case .failure:
+                self.previewImageView.isHidden = true
+                self.showMediaStatus("Preview unavailable")
+            }
+            self.onAsyncLayoutAffectingContentLoaded?()
+        }
         contentStackView.addArrangedSubview(previewImageView)
         
         let aspectRatio = mediaAspectRatio(width: video.width, height: video.height)

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Attachments.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Attachments.swift
@@ -47,6 +47,45 @@ struct ImageAttachmentPreviewLayout {
         return CGFloat(rowCount) * tileHeight
             + CGFloat(max(0, rowCount - 1)) * gallerySpacing
     }
+
+    static func galleryFrame(index: Int, imageCount: Int, tileSize: CGSize) -> CGRect {
+        guard index >= 0, index < imageCount else { return .zero }
+
+        if imageCount == 3 {
+            switch index {
+            case 0:
+                return CGRect(
+                    x: 0,
+                    y: 0,
+                    width: tileSize.width,
+                    height: tileSize.height * 2 + gallerySpacing
+                )
+            case 1:
+                return CGRect(
+                    x: tileSize.width + gallerySpacing,
+                    y: 0,
+                    width: tileSize.width,
+                    height: tileSize.height
+                )
+            default:
+                return CGRect(
+                    x: tileSize.width + gallerySpacing,
+                    y: tileSize.height + gallerySpacing,
+                    width: tileSize.width,
+                    height: tileSize.height
+                )
+            }
+        }
+
+        let column = index % 2
+        let row = index / 2
+        return CGRect(
+            x: CGFloat(column) * (tileSize.width + gallerySpacing),
+            y: CGFloat(row) * (tileSize.height + gallerySpacing),
+            width: tileSize.width,
+            height: tileSize.height
+        )
+    }
 }
 
 extension MessageCell {
@@ -140,8 +179,6 @@ extension MessageCell {
         // // print("🖼️ Setting up image attachments constraints - spacing: 20px")
         
         // Calculate available width first - needed for constraints
-        let maxImagesPerRow = 2
-        let imageSpacing = ImageAttachmentPreviewLayout.gallerySpacing
         // Calculate available width based on actual layout constraints
         // Account for: avatar leading (16) + avatar width (40) + avatar spacing (10) + content trailing margin (16)
         let totalMargins: CGFloat = 16 + 40 + 10 + 16 // Total: 82px
@@ -192,10 +229,6 @@ extension MessageCell {
         containerHeightConstraint.priority = UILayoutPriority.defaultHigh
         containerHeightConstraint.isActive = true
         
-        var currentX: CGFloat = 0
-        var currentY: CGFloat = 0
-        var imagesInCurrentRow = 0
-        
         for (index, attachment) in attachments.enumerated() {
             let attachmentId = attachment.id
             // Create image view for this attachment
@@ -216,28 +249,26 @@ extension MessageCell {
             imageAttachmentsContainer!.addSubview(imageView)
             imageAttachmentViews.append(imageView)
             
-            // Calculate position
-            let previewSize = isGallery ? galleryTileSize : singlePreviewSize
-            if imagesInCurrentRow >= maxImagesPerRow || (currentX + previewSize.width > availableWidth) {
-                // Move to next row if we've hit the max images per row OR if the next image would overflow
-                currentX = 0
-                currentY += galleryTileSize.height + imageSpacing
-                imagesInCurrentRow = 0
-            }
-
-            let remainingWidth = availableWidth - currentX
-            let actualImageWidth = min(previewSize.width, remainingWidth)
+            let previewFrame = isGallery
+                ? ImageAttachmentPreviewLayout.galleryFrame(
+                    index: index,
+                    imageCount: attachments.count,
+                    tileSize: galleryTileSize
+                )
+                : CGRect(origin: .zero, size: singlePreviewSize)
+            let remainingWidth = availableWidth - previewFrame.minX
+            let actualImageWidth = min(previewFrame.width, remainingWidth)
             
             // Create width constraint with lower priority to prevent conflicts
             let widthConstraint = imageView.widthAnchor.constraint(equalToConstant: actualImageWidth)
             widthConstraint.priority = UILayoutPriority(999) // High but not required
             let imageHeightConstraint = imageView.heightAnchor.constraint(
-                equalToConstant: previewSize.height
+                equalToConstant: previewFrame.height
             )
             
             NSLayoutConstraint.activate([
-                imageView.leadingAnchor.constraint(equalTo: imageAttachmentsContainer!.leadingAnchor, constant: currentX),
-                imageView.topAnchor.constraint(equalTo: imageAttachmentsContainer!.topAnchor, constant: currentY),
+                imageView.leadingAnchor.constraint(equalTo: imageAttachmentsContainer!.leadingAnchor, constant: previewFrame.minX),
+                imageView.topAnchor.constraint(equalTo: imageAttachmentsContainer!.topAnchor, constant: previewFrame.minY),
                 widthConstraint,
                 imageHeightConstraint,
                 // Add trailing constraint to ensure image doesn't exceed container bounds - this is the critical constraint
@@ -266,7 +297,7 @@ extension MessageCell {
             } else {
                 // For real messages, load from server using Kingfisher
                 if let url = URL(string: viewState.formatUrl(fromId: attachmentId, withTag: "attachments")) {
-                    let downsampleSize = previewSize
+                    let downsampleSize = previewFrame.size
                     imageView.kf.setImage(
                         with: url,
                         placeholder: UIImage(systemName: "photo"),
@@ -318,9 +349,6 @@ extension MessageCell {
                 }
             }
             
-            // Update position for next image
-            currentX += actualImageWidth + imageSpacing
-            imagesInCurrentRow += 1
         }
     }
 

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Attachments.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Attachments.swift
@@ -10,8 +10,47 @@ import Types
 import Kingfisher
 import AVKit
 
+struct ImageAttachmentPreviewLayout {
+    static let singleMaxWidth: CGFloat = 280
+    static let singleMaxHeight: CGFloat = 320
+    static let galleryMaxTileWidth: CGFloat = 150
+    static let gallerySpacing: CGFloat = 8
+
+    static func singleSize(sourceSize: CGSize?, availableWidth: CGFloat) -> CGSize {
+        let maxWidth = max(1, min(availableWidth, singleMaxWidth))
+        let fallback = CGSize(width: maxWidth, height: maxWidth * 0.75)
+
+        guard let sourceSize,
+              sourceSize.width > 0,
+              sourceSize.height > 0 else {
+            return fallback
+        }
+
+        let scale = min(maxWidth / sourceSize.width, singleMaxHeight / sourceSize.height)
+        return CGSize(
+            width: max(1, sourceSize.width * scale),
+            height: max(1, sourceSize.height * scale)
+        )
+    }
+
+    static func galleryTileSize(availableWidth: CGFloat) -> CGSize {
+        let width = max(
+            1,
+            min((availableWidth - gallerySpacing) / 2, galleryMaxTileWidth)
+        )
+        return CGSize(width: width, height: width)
+    }
+
+    static func galleryHeight(imageCount: Int, tileHeight: CGFloat) -> CGFloat {
+        guard imageCount > 0 else { return 0 }
+        let rowCount = (imageCount + 1) / 2
+        return CGFloat(rowCount) * tileHeight
+            + CGFloat(max(0, rowCount - 1)) * gallerySpacing
+    }
+}
+
 extension MessageCell {
-    internal func loadImageAttachments(attachments: [String], viewState: ViewState) {
+    internal func loadImageAttachments(attachments: [Types.File], viewState: ViewState) {
         guard !attachments.isEmpty else {
             // If no attachments, remove any existing container
             imageAttachmentsContainer?.removeFromSuperview()
@@ -69,6 +108,7 @@ extension MessageCell {
         let spacerView = contentView.viewWithTag(1001)!
         
         // Clear any existing constraints for the container
+        NSLayoutConstraint.deactivate(imageAttachmentsContainer!.constraints)
         for constraint in contentView.constraints {
             if constraint.firstItem === imageAttachmentsContainer ||
                constraint.secondItem === imageAttachmentsContainer {
@@ -101,11 +141,12 @@ extension MessageCell {
         
         // Calculate available width first - needed for constraints
         let maxImagesPerRow = 2
-        let imageSpacing: CGFloat = 8
+        let imageSpacing = ImageAttachmentPreviewLayout.gallerySpacing
         // Calculate available width based on actual layout constraints
         // Account for: avatar leading (16) + avatar width (40) + avatar spacing (10) + content trailing margin (16)
         let totalMargins: CGFloat = 16 + 40 + 10 + 16 // Total: 82px
-        let availableWidth = UIScreen.main.bounds.width - totalMargins
+        let measuredWidth = window?.bounds.width ?? UIScreen.main.bounds.width
+        let availableWidth = measuredWidth - totalMargins
         
         // Add a maximum width constraint to prevent overflow - use lower priority to avoid conflicts
         let maxWidthConstraint = imageAttachmentsContainer!.widthAnchor.constraint(lessThanOrEqualToConstant: availableWidth)
@@ -130,24 +171,40 @@ extension MessageCell {
             maxWidthConstraint
         ])
         
-        // Create image views for each attachment
-        let finalImageWidth: CGFloat = attachments.count == 1 ? min(availableWidth * 0.7, 220) : min((availableWidth - imageSpacing) / 2, 150)
-        let imageHeight: CGFloat = attachments.count == 1 ? min(finalImageWidth * 0.75, 165) : min(finalImageWidth * 0.75, 110)
-        
-        // print("🖼️ Calculated sizes - Image width: \(finalImageWidth), Image height: \(imageHeight), Available width: \(availableWidth), Screen width: \(UIScreen.main.bounds.width)")
+        let isGallery = attachments.count > 1
+        let galleryTileSize = ImageAttachmentPreviewLayout.galleryTileSize(availableWidth: availableWidth)
+        let singleSourceSize = attachments.first.flatMap {
+            imageSourceSize(for: $0, viewState: viewState)
+        }
+        let singlePreviewSize = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: singleSourceSize,
+            availableWidth: availableWidth
+        )
+        let initialContainerHeight = isGallery
+            ? ImageAttachmentPreviewLayout.galleryHeight(
+                imageCount: attachments.count,
+                tileHeight: galleryTileSize.height
+            )
+            : singlePreviewSize.height
+        let containerHeightConstraint = imageAttachmentsContainer!.heightAnchor.constraint(
+            equalToConstant: initialContainerHeight
+        )
+        containerHeightConstraint.priority = UILayoutPriority.defaultHigh
+        containerHeightConstraint.isActive = true
         
         var currentX: CGFloat = 0
         var currentY: CGFloat = 0
         var imagesInCurrentRow = 0
         
-        for (index, attachmentId) in attachments.enumerated() {
+        for (index, attachment) in attachments.enumerated() {
+            let attachmentId = attachment.id
             // Create image view for this attachment
             let imageView = UIImageView()
             imageView.translatesAutoresizingMaskIntoConstraints = false
-            imageView.contentMode = .scaleAspectFit // Show entire image, preserve aspect ratio
+            imageView.contentMode = .scaleAspectFit
             imageView.clipsToBounds = true
             imageView.layer.cornerRadius = 8
-            imageView.backgroundColor = UIColor.gray.withAlphaComponent(0.1) // Lighter background
+            imageView.backgroundColor = UIColor.gray.withAlphaComponent(0.1)
             imageView.isUserInteractionEnabled = true
             imageView.tag = index // Store index for tap handling
             imageView.accessibilityIdentifier = attachmentId
@@ -160,30 +217,29 @@ extension MessageCell {
             imageAttachmentViews.append(imageView)
             
             // Calculate position
-            if imagesInCurrentRow >= maxImagesPerRow || (currentX + finalImageWidth > availableWidth) {
+            let previewSize = isGallery ? galleryTileSize : singlePreviewSize
+            if imagesInCurrentRow >= maxImagesPerRow || (currentX + previewSize.width > availableWidth) {
                 // Move to next row if we've hit the max images per row OR if the next image would overflow
                 currentX = 0
-                let rowImageHeight = min(finalImageWidth * 0.75, 165) // Match the updated max height
-                currentY += rowImageHeight + 10 // Match container calculation
+                currentY += galleryTileSize.height + imageSpacing
                 imagesInCurrentRow = 0
             }
-            
-            // Set up simple constraints for this image
-            let imageViewHeight = min(finalImageWidth * 0.75, 165) // Match container calculation with updated max height
-            
-            // Ensure the image width doesn't exceed the remaining space in the container
+
             let remainingWidth = availableWidth - currentX
-            let actualImageWidth = min(finalImageWidth, remainingWidth)
+            let actualImageWidth = min(previewSize.width, remainingWidth)
             
             // Create width constraint with lower priority to prevent conflicts
             let widthConstraint = imageView.widthAnchor.constraint(equalToConstant: actualImageWidth)
             widthConstraint.priority = UILayoutPriority(999) // High but not required
+            let imageHeightConstraint = imageView.heightAnchor.constraint(
+                equalToConstant: previewSize.height
+            )
             
             NSLayoutConstraint.activate([
                 imageView.leadingAnchor.constraint(equalTo: imageAttachmentsContainer!.leadingAnchor, constant: currentX),
                 imageView.topAnchor.constraint(equalTo: imageAttachmentsContainer!.topAnchor, constant: currentY),
                 widthConstraint,
-                imageView.heightAnchor.constraint(equalToConstant: imageViewHeight),
+                imageHeightConstraint,
                 // Add trailing constraint to ensure image doesn't exceed container bounds - this is the critical constraint
                 imageView.trailingAnchor.constraint(lessThanOrEqualTo: imageAttachmentsContainer!.trailingAnchor)
             ])
@@ -198,6 +254,8 @@ extension MessageCell {
                 // For pending messages, show local image data with loading overlay
                 if let localImage = UIImage(data: localImageData) {
                     imageView.image = localImage
+                    imageView.backgroundColor = .clear
+                    imageView.contentMode = isGallery ? .scaleAspectFill : .scaleAspectFit
                     
                     // Add loading overlay to show upload progress
                     addLoadingOverlayToImageView(imageView, attachmentId: attachmentId, queuedMessage: queuedMessage)
@@ -208,7 +266,7 @@ extension MessageCell {
             } else {
                 // For real messages, load from server using Kingfisher
                 if let url = URL(string: viewState.formatUrl(fromId: attachmentId, withTag: "attachments")) {
-                    let downsampleSize = CGSize(width: finalImageWidth, height: imageHeight)
+                    let downsampleSize = previewSize
                     imageView.kf.setImage(
                         with: url,
                         placeholder: UIImage(systemName: "photo"),
@@ -221,11 +279,22 @@ extension MessageCell {
                         ],
                         completionHandler: { [weak self] result in
                             switch result {
-                            case .success(_):
+                            case .success(let value):
                                 // Ensure cell hasn't been reused for a different message
                                 if let currentAttachments = self?.currentMessage?.attachments,
                                    currentAttachments.contains(where: { $0.id == attachmentId }) {
-                                    // Success: keep the loaded image
+                                    imageView.backgroundColor = .clear
+                                    imageView.contentMode = isGallery ? .scaleAspectFill : .scaleAspectFit
+
+                                    if !isGallery, singleSourceSize == nil {
+                                        let fittedSize = ImageAttachmentPreviewLayout.singleSize(
+                                            sourceSize: value.image.size,
+                                            availableWidth: availableWidth
+                                        )
+                                        widthConstraint.constant = fittedSize.width
+                                        imageHeightConstraint.constant = fittedSize.height
+                                        containerHeightConstraint.constant = fittedSize.height
+                                    }
 
                                     // Force layout update to ensure proper positioning
                                     self?.contentView.setNeedsLayout()
@@ -253,18 +322,27 @@ extension MessageCell {
             currentX += actualImageWidth + imageSpacing
             imagesInCurrentRow += 1
         }
-        
-        // Calculate exact container height based on actual image layout
-        let numberOfRows = (attachments.count + maxImagesPerRow - 1) / maxImagesPerRow
-        let containerImageHeight: CGFloat = min(finalImageWidth * 0.75, 165) // Updated max height to match image constraints
-        let totalHeight = CGFloat(numberOfRows) * containerImageHeight + CGFloat(max(0, numberOfRows - 1)) * 10 // 10px spacing between rows
-        
-        let heightConstraint = imageAttachmentsContainer!.heightAnchor.constraint(equalToConstant: totalHeight)
-        heightConstraint.priority = UILayoutPriority.defaultHigh // Lower priority to prevent conflicts
-        heightConstraint.isActive = true
-        
-        // // print("🖼️ Set fixed container height: \(totalHeight) for \(numberOfRows) rows")
-        // // print("🖼️ Image details - Width: \(finalImageWidth), Height: \(containerImageHeight), Attachments: \(attachments.count)")
+    }
+
+    private func imageSourceSize(for attachment: Types.File, viewState: ViewState) -> CGSize? {
+        if case .image(let metadata) = attachment.metadata,
+           metadata.width > 0,
+           metadata.height > 0 {
+            return CGSize(width: CGFloat(metadata.width), height: CGFloat(metadata.height))
+        }
+
+        guard isPendingMessage,
+              let currentMessage,
+              let channelQueuedMessages = viewState.queuedMessages[currentMessage.channel],
+              let queuedMessage = channelQueuedMessages.first(where: { $0.nonce == currentMessage.id }),
+              let localImageData = queuedMessage.attachmentData.first(where: {
+                  $0.1.contains(attachment.id.replacingOccurrences(of: "\(queuedMessage.nonce)_", with: ""))
+              })?.0,
+              let image = UIImage(data: localImageData) else {
+            return nil
+        }
+
+        return image.size
     }
     
     internal func loadFileAttachments(attachments: [Types.File], viewState: ViewState) {

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Layout.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Layout.swift
@@ -24,8 +24,8 @@ extension MessageCell {
     }
 
     private func updateTopConstraintConstants(offset: CGFloat) {
-        continuationNoReplyConstraints.first?.constant = 8 + offset
-        continuationWithReplyConstraints.first?.constant = 8
+        continuationNoReplyConstraints.first?.constant = 4 + offset
+        continuationWithReplyConstraints.first?.constant = 6
         nonContinuationNoReplyConstraints.first?.constant = 8 + offset
         nonContinuationWithReplyConstraints.first?.constant = 8
     }

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Setup.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Setup.swift
@@ -77,11 +77,12 @@ extension MessageCell {
         // Add visual feedback for tap
         replyView.layer.cornerRadius = 4
         replyView.layer.masksToBounds = true
+        replyView.backgroundColor = (UIColor(named: "bgGray12") ?? .secondarySystemBackground).withAlphaComponent(0.7)
         
         // Reply indicator icon
         replyIndicatorImageView.translatesAutoresizingMaskIntoConstraints = false
         replyIndicatorImageView.image = UIImage(systemName: "arrow.turn.up.right")
-        replyIndicatorImageView.tintColor = .bgOrane07
+        replyIndicatorImageView.tintColor = UIColor(named: "textGray04") ?? .secondaryLabel
         replyIndicatorImageView.contentMode = .scaleAspectFit
         replyView.addSubview(replyIndicatorImageView)
 
@@ -97,7 +98,7 @@ extension MessageCell {
         // Reply author label
         replyAuthorLabel.translatesAutoresizingMaskIntoConstraints = false
         replyAuthorLabel.font = UIFont.boldSystemFont(ofSize: 13)
-        replyAuthorLabel.textColor = .bgOrane07
+        replyAuthorLabel.textColor = .textDefaultGray01
         // Keep author compact so preview text starts right after a minimum gap.
         replyAuthorLabel.setContentHuggingPriority(.required, for: .horizontal)
         replyAuthorLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -118,7 +119,7 @@ extension MessageCell {
         // Reply content label
         replyContentLabel.translatesAutoresizingMaskIntoConstraints = false
         replyContentLabel.font = UIFont.systemFont(ofSize: 13)
-        replyContentLabel.textColor = .bgOrane07
+        replyContentLabel.textColor = UIColor(named: "textGray04") ?? .secondaryLabel
         replyContentLabel.lineBreakMode = .byTruncatingTail
         replyContentLabel.numberOfLines = 1
         // Let preview text absorb compression/truncation first, Discord-like behavior.
@@ -169,8 +170,8 @@ extension MessageCell {
         
         // Time label
         timeLabel.translatesAutoresizingMaskIntoConstraints = false
-        timeLabel.font = UIFont.systemFont(ofSize: 12)
-        timeLabel.textColor = .textGray06
+        timeLabel.font = UIFont.systemFont(ofSize: 12, weight: .medium)
+        timeLabel.textColor = UIColor(named: "textGray04") ?? .secondaryLabel
         contentView.addSubview(timeLabel)
         
         // Bridge badge label
@@ -192,7 +193,7 @@ extension MessageCell {
         
         // Content text view - optimized for markdown and performance
         contentLabel.translatesAutoresizingMaskIntoConstraints = false
-        contentLabel.font = UIFont.systemFont(ofSize: 15, weight: .light)
+        contentLabel.font = UIFont.systemFont(ofSize: 15, weight: .regular)
         contentLabel.textColor = .textDefaultGray01
         contentLabel.backgroundColor = .clear // Make background transparent
         contentLabel.isScrollEnabled = false // Disable scrolling
@@ -242,7 +243,7 @@ extension MessageCell {
         replyViewTopConstraint?.isActive = true
 
         // Create height constraint with lower priority
-        let replyHeightConstraint = replyView.heightAnchor.constraint(equalToConstant: 18)
+        let replyHeightConstraint = replyView.heightAnchor.constraint(equalToConstant: 22)
         replyHeightConstraint.priority = UILayoutPriority(999) // Just below required but still high
         replyHeightConstraint.isActive = true
 
@@ -313,11 +314,11 @@ extension MessageCell {
         // These are toggled via isActive in updateAppearanceForContinuation() instead of
         // scanning and removing/recreating constraints on every cell reuse.
         continuationNoReplyConstraints = [
-            contentLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            contentLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 4),
             contentLabel.leadingAnchor.constraint(equalTo: avatarImageView.trailingAnchor, constant: 10)
         ]
         continuationWithReplyConstraints = [
-            contentLabel.topAnchor.constraint(equalTo: replyView.bottomAnchor, constant: 8),
+            contentLabel.topAnchor.constraint(equalTo: replyView.bottomAnchor, constant: 6),
             contentLabel.leadingAnchor.constraint(equalTo: avatarImageView.trailingAnchor, constant: 10)
         ]
         let ncNoReplyUsernameHeight = usernameLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 19)

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
@@ -636,7 +636,11 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
     }
     
     // New function to create attributed text with clickable mentions
-    private func createAttributedTextWithClickableMentions(from text: String, viewState: ViewState) -> NSAttributedString {
+    private func createAttributedTextWithClickableMentions(
+        from text: String,
+        viewState: ViewState,
+        mentionsEveryone: Bool
+    ) -> NSAttributedString {
         let mutableAttributedString = NSMutableAttributedString(string: text)
         
         // Set default attributes for the entire text
@@ -830,6 +834,22 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
             // print("Error creating regex for mentions: \(error)")
         }
         
+        if mentionsEveryone {
+            let foregroundColor = UIColor(named: "textYellow07") ?? UIColor.systemYellow
+            let backgroundColor = UIColor(red: 49 / 255, green: 45 / 255, blue: 29 / 255, alpha: 1)
+            for range in MentionInputUtilities.everyoneMentionRanges(in: mutableAttributedString.string) {
+                guard MentionInputUtilities.isValid(
+                    range: range,
+                    inUTF16Length: mutableAttributedString.length
+                ) else { continue }
+                mutableAttributedString.addAttributes([
+                    .foregroundColor: foregroundColor,
+                    .backgroundColor: backgroundColor,
+                    .font: UIFont.systemFont(ofSize: 15, weight: .semibold)
+                ], range: range)
+            }
+        }
+
         return mutableAttributedString
     }
     
@@ -1744,7 +1764,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
             return
         }
         let cacheKey = message.id as NSString
-        let hasMentions = content.contains("<@") || content.contains("<#")
+        let hasMentions = content.contains("<@") || content.contains("<#") || message.mentionsEveryone
 
         // Check message-level cache for the pre-emoji attributed string
         if let cached = MessageCell.attributedStringCache.object(forKey: cacheKey) {
@@ -1761,7 +1781,11 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         let baseAttributedString: NSAttributedString
 
         if hasMentions {
-            baseAttributedString = createAttributedTextWithClickableMentions(from: processedContent, viewState: viewState)
+            baseAttributedString = createAttributedTextWithClickableMentions(
+                from: processedContent,
+                viewState: viewState,
+                mentionsEveryone: message.mentionsEveryone
+            )
         } else {
             baseAttributedString = processMarkdownOptimized(processedContent)
         }

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
@@ -447,7 +447,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         usernameLabel.font = UIFont.boldSystemFont(ofSize: 16)
         
         let showVerified = author.hasVerifiedBadge()
-        usernameLabel.textColor = showVerified ? .systemYellow : .white
+        usernameLabel.textColor = .white
         usernameVerifiedBadgeImageView.image = UIImage(systemName: "checkmark.seal.fill")
         usernameVerifiedBadgeImageView.isHidden = !showVerified
         usernameVerifiedBadgeWidthConstraint?.constant = showVerified ? 14 : 0
@@ -507,10 +507,10 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
 
         if author.bot != nil {
             badge = message.masquerade == nil
-                ? ("BOT", UIColor(named: "bgPurple10") ?? .systemPurple)
-                : ("BRIDGE", UIColor(named: "bgRed07") ?? .systemPink)
+                ? ("BOT", (UIColor(named: "bgPurple10") ?? .systemPurple).withAlphaComponent(0.8))
+                : ("BRIDGE", (UIColor(named: "bgGray10") ?? .systemGray).withAlphaComponent(0.85))
         } else if isNewAccount(author) {
-            badge = ("NEW", UIColor(named: "bgGreen07") ?? .systemGreen)
+            badge = ("NEW", (UIColor(named: "bgGreen07") ?? .systemGreen).withAlphaComponent(0.75))
         } else {
             badge = nil
         }
@@ -614,7 +614,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
                     let userId = String(result[userIdRange])
                     
                     // Try to find user in viewState
-                    if let user = viewState.users[userId] {
+                    if let user = viewState.users[userId] ?? viewState.allEventUsers[userId] {
                         // Get the mention range
                         let mentionRange = Range(match.range, in: result)!
                         
@@ -624,7 +624,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
                     } else {
                         // If user not found, replace with @Unknown User to avoid showing raw ID
                         let mentionRange = Range(match.range, in: result)!
-                        result.replaceSubrange(mentionRange, with: "@Unknown User")
+                        result.replaceSubrange(mentionRange, with: "@unknown-user")
                     }
                 }
             }
@@ -784,19 +784,16 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
             for match in matches.reversed() {
                 if let userIdRange = Range(match.range(at: 1), in: mutableAttributedString.string) {
                     let userId = String(mutableAttributedString.string[userIdRange])
-                    
-                    // Try to find user in viewState
-                    if let user = viewState.users[userId] {
-                        // Get the mention range in the current string
-                        let mentionRange = match.range
-                        
-                        // Safety check for range bounds in mutable string
-                        guard mentionRange.location >= 0,
-                              mentionRange.location < mutableAttributedString.length,
-                              mentionRange.location + mentionRange.length <= mutableAttributedString.length else {
-                            // print("DEBUG: Invalid mention range: \(mentionRange) for string length: \(mutableAttributedString.length)")
-                            continue
-                        }
+
+                    let mentionRange = match.range
+                    guard mentionRange.location >= 0,
+                          mentionRange.location < mutableAttributedString.length,
+                          mentionRange.location + mentionRange.length <= mutableAttributedString.length else {
+                        continue
+                    }
+
+                    // Try both user stores before falling back to a privacy-safe label.
+                    if let user = viewState.users[userId] ?? viewState.allEventUsers[userId] {
                         
                         // Replace the mention with username (use display name if available)
                         let displayName = user.display_name ?? user.username
@@ -827,6 +824,17 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
                         } catch {
                             // print("DEBUG: Error adding attributes to mention: \(error)")
                         }
+                    } else {
+                        let mentionText = "@unknown-user"
+                        mutableAttributedString.replaceCharacters(in: mentionRange, with: mentionText)
+                        let newRange = NSRange(
+                            location: mentionRange.location,
+                            length: (mentionText as NSString).length
+                        )
+                        mutableAttributedString.addAttributes([
+                            .foregroundColor: UIColor.secondaryLabel,
+                            .font: UIFont.systemFont(ofSize: 15, weight: .semibold)
+                        ], range: newRange)
                     }
                 }
             }
@@ -1178,6 +1186,17 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         // print("✅ MessageCell.clearHighlight() COMPLETED")
     }
     
+    private func replyAttachmentSummary(_ attachments: [Types.File]) -> String {
+        guard attachments.count == 1, let attachment = attachments.first else {
+            return "\(attachments.count) attachments"
+        }
+
+        if attachment.content_type.hasPrefix("image/") { return "Photo" }
+        if attachment.content_type.hasPrefix("video/") { return "Video" }
+        if attachment.content_type.hasPrefix("audio/") { return "Audio" }
+        return attachment.filename
+    }
+
     private func configureReplyView(message: Message, replies: [String], viewState: ViewState) {
         // Remove the continuation check - allow reply view for continuations too
         
@@ -1245,12 +1264,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
                         replyContentLabel.text = processedContent
                         replyContentLabel.font = UIFont.systemFont(ofSize: 12) // Reset to normal font
                     } else if !(replyMessage.attachments?.isEmpty ?? true) {
-                        let attachmentCount = replyMessage.attachments?.count ?? 0
-                        if attachmentCount == 1 {
-                            replyContentLabel.text = "[attachment]"
-                        } else {
-                            replyContentLabel.text = "[\(attachmentCount) attachments]"
-                        }
+                        replyContentLabel.text = replyAttachmentSummary(replyMessage.attachments ?? [])
                         replyContentLabel.font = UIFont.systemFont(ofSize: 12) // Reset to normal font
                     } else {
                         replyContentLabel.text = ""
@@ -1767,7 +1781,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         let hasMentions = content.contains("<@") || content.contains("<#") || message.mentionsEveryone
 
         // Check message-level cache for the pre-emoji attributed string
-        if let cached = MessageCell.attributedStringCache.object(forKey: cacheKey) {
+        if !hasMentions, let cached = MessageCell.attributedStringCache.object(forKey: cacheKey) {
             let mutableCopy = NSMutableAttributedString(attributedString: cached)
             processCustomEmojis(in: mutableCopy, textView: contentLabel)
             contentLabel.attributedText = mutableCopy
@@ -1791,7 +1805,9 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         }
 
         // Cache the pre-emoji result (immutable copy)
-        MessageCell.attributedStringCache.setObject(baseAttributedString, forKey: cacheKey)
+        if !hasMentions {
+            MessageCell.attributedStringCache.setObject(baseAttributedString, forKey: cacheKey)
+        }
 
         // Apply emoji processing on a mutable copy
         let mutableAttributedText = NSMutableAttributedString(attributedString: baseAttributedString)
@@ -1915,7 +1931,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
             } else if hasImageAttachments {
                 // Image attachments already have bottom constraint
             } else if !hasAttachments {
-                let bottomConstraint = contentLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -16)
+                let bottomConstraint = contentLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -8)
                 bottomConstraint.priority = UILayoutPriority.defaultHigh
                 bottomConstraint.isActive = true
                 // PERF Issue #9: Track for efficient deactivation in clearContentLabelBottomConstraints()
@@ -1930,7 +1946,8 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         
         // Minimum height constraint
         contentViewMinHeightConstraint?.isActive = false
-        let minHeightConstraint = contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 50)
+        let minimumHeight: CGFloat = isContinuation ? 28 : 50
+        let minHeightConstraint = contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: minimumHeight)
         minHeightConstraint.priority = UILayoutPriority.defaultLow
         minHeightConstraint.isActive = true
         contentViewMinHeightConstraint = minHeightConstraint

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
@@ -119,7 +119,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
     
     // Callback for message actions
     var onMessageAction: ((MessageAction, Message) -> Void)?
-    var onImageTapped: ((UIImage, URL?, String?) -> Void)?
+    var onImageTapped: (([FullScreenImageItem], Int) -> Void)?
     /// Called when async content (images, link previews) finishes loading and may have changed cell height.
     var onAsyncContentLoaded: ((String) -> Void)?
     var onAvatarTap: (() -> Void)?
@@ -1542,20 +1542,29 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
     @objc internal func handleImageCellTap(_ gesture: UITapGestureRecognizer) {
         guard let imageView = gesture.view as? UIImageView,
               let image = imageView.image else { return }
-        
-        // Default fallback: still open preview if URL resolution fails
-        var originalURL: URL? = nil
-        var sessionToken: String? = nil
-        
-        
-        if let viewState = viewState,
-           let attachmentId = imageView.accessibilityIdentifier {
-            let urlString = viewState.formatUrl(fromId: attachmentId, withTag: "attachments")
-            originalURL = URL(string: urlString)
-            sessionToken = viewState.sessionToken
+
+        guard let viewState else {
+            onImageTapped?(
+                [FullScreenImageItem(previewImage: image, originalImageURL: nil, sessionToken: nil)],
+                0
+            )
+            return
         }
-        
-        onImageTapped?(image, originalURL, sessionToken)
+
+        let items = imageAttachmentViews.map { attachmentImageView in
+            let originalURL = attachmentImageView.accessibilityIdentifier.flatMap { attachmentId in
+                URL(string: viewState.formatUrl(fromId: attachmentId, withTag: "attachments"))
+            }
+            return FullScreenImageItem(
+                previewImage: attachmentImageView.image,
+                originalImageURL: originalURL,
+                sessionToken: viewState.sessionToken
+            )
+        }
+
+        guard !items.isEmpty else { return }
+        let initialIndex = min(max(0, imageView.tag), items.count - 1)
+        onImageTapped?(items, initialIndex)
     }
     
 

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
@@ -1884,8 +1884,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         
         // Load image attachments
         if !imageAttachments.isEmpty {
-            let imageIds = imageAttachments.map { $0.id }
-            loadImageAttachments(attachments: imageIds, viewState: viewState)
+            loadImageAttachments(attachments: imageAttachments, viewState: viewState)
         }
         
         // Load file attachments

--- a/Revolt/Pages/Channel/Messagable/Views/MessageInputView.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageInputView.swift
@@ -7,6 +7,137 @@ import UIKit
 import Types
 import Combine
 
+struct MentionReplacement {
+    let text: String
+    let replacedRange: NSRange
+    let insertedRange: NSRange
+    let selectedRange: NSRange
+}
+
+enum MentionInputUtilities {
+    static func isValid(range: NSRange, inUTF16Length length: Int) -> Bool {
+        range.location != NSNotFound
+            && range.location <= length
+            && range.length <= length - range.location
+    }
+
+    static func activeMentionRange(in text: String, selectedRange: NSRange) -> NSRange? {
+        let nsText = text as NSString
+        guard selectedRange.length == 0,
+              isValid(range: selectedRange, inUTF16Length: nsText.length) else {
+            return nil
+        }
+
+        let prefixRange = NSRange(location: 0, length: selectedRange.location)
+        let atRange = nsText.range(of: "@", options: .backwards, range: prefixRange)
+        guard atRange.location != NSNotFound else { return nil }
+
+        let mentionRange = NSRange(
+            location: atRange.location,
+            length: selectedRange.location - atRange.location
+        )
+        let candidate = nsText.substring(with: mentionRange)
+        guard !candidate.contains(where: { $0.isWhitespace }) else { return nil }
+        return mentionRange
+    }
+
+    static func searchText(in text: String, selectedRange: NSRange) -> String? {
+        guard let range = activeMentionRange(in: text, selectedRange: selectedRange) else {
+            return nil
+        }
+        let nsText = text as NSString
+        return nsText.substring(with: NSRange(
+            location: range.location + 1,
+            length: max(0, range.length - 1)
+        ))
+    }
+
+    static func replacingActiveMention(
+        in text: String,
+        selectedRange: NSRange,
+        with replacement: String
+    ) -> MentionReplacement? {
+        guard let activeRange = activeMentionRange(in: text, selectedRange: selectedRange) else {
+            return nil
+        }
+
+        let nsText = text as NSString
+        var replacedRange = activeRange
+        if replacement.last?.isWhitespace == true,
+           NSMaxRange(replacedRange) < nsText.length,
+           nsText.character(at: NSMaxRange(replacedRange)) == 32 {
+            replacedRange.length += 1
+        }
+
+        let mutable = NSMutableString(string: text)
+        mutable.replaceCharacters(in: replacedRange, with: replacement)
+        let insertedRange = NSRange(
+            location: replacedRange.location,
+            length: (replacement as NSString).length
+        )
+        return MentionReplacement(
+            text: mutable as String,
+            replacedRange: replacedRange,
+            insertedRange: insertedRange,
+            selectedRange: NSRange(location: NSMaxRange(insertedRange), length: 0)
+        )
+    }
+
+    static func shouldIncludeEveryone(searchText: String, canMentionEveryone: Bool) -> Bool {
+        canMentionEveryone
+            && (searchText.isEmpty || "everyone".hasPrefix(searchText.lowercased()))
+    }
+
+    /// Finds literal mass mentions while excluding escaped text and inline/fenced code.
+    static func everyoneMentionRanges(in text: String) -> [NSRange] {
+        let nsText = text as NSString
+        let mention = "@everyone" as NSString
+        var ranges: [NSRange] = []
+        var codeDelimiterLength: Int?
+        var index = 0
+
+        while index < nsText.length {
+            let character = nsText.character(at: index)
+
+            if character == 92 { // Backslash escapes the next UTF-16 code unit.
+                index += min(2, nsText.length - index)
+                continue
+            }
+
+            if character == 96 { // Backtick.
+                var delimiterLength = 1
+                while index + delimiterLength < nsText.length,
+                      nsText.character(at: index + delimiterLength) == 96 {
+                    delimiterLength += 1
+                }
+
+                let normalizedLength = min(delimiterLength, 3)
+                if let activeLength = codeDelimiterLength {
+                    if normalizedLength == activeLength {
+                        codeDelimiterLength = nil
+                    }
+                } else {
+                    codeDelimiterLength = normalizedLength
+                }
+                index += delimiterLength
+                continue
+            }
+
+            if codeDelimiterLength == nil,
+               index + mention.length <= nsText.length,
+               nsText.substring(with: NSRange(location: index, length: mention.length)) == mention as String {
+                ranges.append(NSRange(location: index, length: mention.length))
+                index += mention.length
+                continue
+            }
+
+            index += 1
+        }
+
+        return ranges
+    }
+}
+
 // MARK: - MentionData structure for storing mention information
 public struct MentionData {
     let userId: String
@@ -254,24 +385,12 @@ class MessageInputView: UIView {
     
     // Check for mention in text
     func checkForMention(in text: String) {
-        // print("DEBUG: checkForMention called with text: '\(text)'")
-        
-        // Find the last @ symbol and extract the search term
-        if let lastAtIndex = text.lastIndex(of: "@") {
-            let searchStartIndex = text.index(after: lastAtIndex)
-            let searchText = String(text[searchStartIndex...])
-            
-            // Only show mentions if the search text doesn't contain spaces
-            // This ensures we only show mentions when actively typing a username
-            if !searchText.contains(" ") && !searchText.contains("\n") {
-                // print("DEBUG: Found @ with search text: '\(searchText)'")
-                mentionInputView?.updateSearch(text: searchText)
-            } else {
-                // print("DEBUG: Search text contains spaces or newlines, hiding mention view")
-                hideMentionView()
-            }
+        if let searchText = MentionInputUtilities.searchText(
+            in: text,
+            selectedRange: textView.selectedRange
+        ) {
+            mentionInputView?.updateSearch(text: searchText)
         } else {
-            // print("DEBUG: No @ found in text, hiding mention view")
             hideMentionView()
         }
     }
@@ -291,8 +410,10 @@ class MessageInputView: UIView {
         let nsText = text as NSString
 
         mentionTokens = mentionTokens.filter { token in
-            guard token.range.location >= 0,
-                  token.range.location + token.range.length <= nsText.length else { return false }
+            guard MentionInputUtilities.isValid(
+                range: token.range,
+                inUTF16Length: nsText.length
+            ) else { return false }
             return nsText.substring(with: token.range) == token.displayText
         }
         removeMentionDataNotPresent(in: text)
@@ -314,14 +435,38 @@ class MessageInputView: UIView {
 
         let attributed = NSMutableAttributedString(string: raw, attributes: baseAttrs)
         for token in mentionTokens {
-            guard token.range.location >= 0,
-                  token.range.location + token.range.length <= (raw as NSString).length else { continue }
+            guard MentionInputUtilities.isValid(
+                range: token.range,
+                inUTF16Length: (raw as NSString).length
+            ) else { continue }
             attributed.addAttribute(.foregroundColor, value: mentionTextColor, range: token.range)
+        }
+        for range in MentionInputUtilities.everyoneMentionRanges(in: raw) {
+            attributed.addAttribute(.foregroundColor, value: mentionTextColor, range: range)
         }
 
         textView.attributedText = attributed
         textView.selectedRange = selected
         textView.typingAttributes = baseAttrs
+    }
+
+    private func adjustMentionTokens(for replacement: MentionReplacement) {
+        let replacedEnd = NSMaxRange(replacement.replacedRange)
+        let delta = replacement.insertedRange.length - replacement.replacedRange.length
+
+        mentionTokens = mentionTokens.compactMap { token in
+            if token.range.location >= replacedEnd {
+                var shifted = token
+                shifted.range.location += delta
+                return shifted
+            }
+
+            if NSIntersectionRange(token.range, replacement.replacedRange).length > 0 {
+                return nil
+            }
+
+            return token
+        }
     }
     
     // MARK: - Cleanup Methods
@@ -1064,13 +1209,11 @@ extension MessageInputView: MentionInputViewDelegate {
         // Get current text
         let currentText = textView.text ?? ""
         
-        // Find the last @ symbol
-        if let lastAtIndex = currentText.lastIndex(of: "@") {
-            // Get the text from @ to the end
-            let startIndex = lastAtIndex
-            let endIndex = currentText.endIndex
-            let range = startIndex..<endIndex
-            
+        if let replacement = MentionInputUtilities.replacingActiveMention(
+            in: currentText,
+            selectedRange: textView.selectedRange,
+            with: "@\(user.username) "
+        ) {
             // Create the mention data
             let displayText = "@\(user.username)"
             let mentionData = MentionData(
@@ -1082,17 +1225,14 @@ extension MessageInputView: MentionInputViewDelegate {
             // Store the mention data
             storeMentionData(mentionData)
             
-            // Replace the text from @ to the end with the display text
-            let newText = currentText.replacingCharacters(in: range, with: "\(displayText) ")
-            textView.text = newText
-
-            let nsText = newText as NSString
-            let insertedRange = nsText.range(of: displayText, options: .backwards)
-            if insertedRange.location != NSNotFound {
-                mentionTokens.append(
-                    MentionToken(userId: user.id, displayText: displayText, range: insertedRange)
-                )
-            }
+            adjustMentionTokens(for: replacement)
+            textView.text = replacement.text
+            textView.selectedRange = replacement.selectedRange
+            mentionTokens.append(MentionToken(
+                userId: user.id,
+                displayText: displayText,
+                range: NSRange(location: replacement.insertedRange.location, length: (displayText as NSString).length)
+            ))
             
             // Update UI
             updateSendButtonState()
@@ -1106,6 +1246,26 @@ extension MessageInputView: MentionInputViewDelegate {
         }
         
         // Hide the mention view
+        hideMentionView()
+    }
+
+    func mentionInputViewDidSelectEveryone(_ mentionView: MentionInputView) {
+        guard let replacement = MentionInputUtilities.replacingActiveMention(
+            in: textView.text ?? "",
+            selectedRange: textView.selectedRange,
+            with: "@everyone "
+        ) else {
+            hideMentionView()
+            return
+        }
+
+        adjustMentionTokens(for: replacement)
+        textView.text = replacement.text
+        textView.selectedRange = replacement.selectedRange
+        updateSendButtonState()
+        updateTextViewHeight()
+        applyMentionStyling()
+        textView.delegate?.textViewDidChange?(textView)
         hideMentionView()
     }
     
@@ -1157,8 +1317,10 @@ extension MessageInputView: MentionInputViewDelegate {
         let mutable = NSMutableString(string: originalText)
         let validTokens = mentionTokens
             .filter { token in
-                token.range.location >= 0
-                    && token.range.location + token.range.length <= mutable.length
+                MentionInputUtilities.isValid(
+                    range: token.range,
+                    inUTF16Length: mutable.length
+                )
                     && mutable.substring(with: token.range) == token.displayText
             }
             .sorted { $0.range.location > $1.range.location }

--- a/Revolt/Pages/Channel/Messagable/Views/MessageInputView.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageInputView.swift
@@ -88,6 +88,44 @@ enum MentionInputUtilities {
             && (searchText.isEmpty || "everyone".hasPrefix(searchText.lowercased()))
     }
 
+    @MainActor
+    static func canMentionEveryone(
+        in channel: Channel?,
+        server: Server?,
+        viewState: ViewState?
+    ) -> Bool {
+        guard let channel else { return false }
+
+        switch channel {
+        case .group_dm_channel:
+            return true
+        case .text_channel:
+            guard let server,
+                  let viewState,
+                  let currentUser = viewState.currentUser else {
+                return false
+            }
+            let member = viewState.members[server.id]?[currentUser.id]
+            let permissions = resolveChannelPermissions(
+                from: currentUser,
+                targettingUser: currentUser,
+                targettingMember: member,
+                channel: channel,
+                server: server
+            )
+            return permissions.contains(.mentionEveryone)
+        default:
+            return false
+        }
+    }
+
+    static func requiresPlainTextEveryoneConfirmation(
+        text: String,
+        canMentionEveryone: Bool
+    ) -> Bool {
+        !canMentionEveryone && !everyoneMentionRanges(in: text).isEmpty
+    }
+
     /// Finds literal mass mentions while excluding escaped text and inline/fenced code.
     static func everyoneMentionRanges(in text: String) -> [NSRange] {
         let nsText = text as NSString
@@ -1015,6 +1053,44 @@ class MessageInputView: UIView {
         
         // Must have at least one non-whitespace character or attachments
         guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || hasAttachments else { return }
+
+        let canMentionEveryone = MentionInputUtilities.canMentionEveryone(
+            in: currentChannel,
+            server: currentServer,
+            viewState: currentViewState
+        )
+        if MentionInputUtilities.requiresPlainTextEveryoneConfirmation(
+            text: text,
+            canMentionEveryone: canMentionEveryone
+        ) {
+            presentPlainTextEveryoneConfirmation(text: text, hasAttachments: hasAttachments)
+            return
+        }
+
+        performSend(text: text, hasAttachments: hasAttachments)
+    }
+
+    private func presentPlainTextEveryoneConfirmation(
+        text: String,
+        hasAttachments: Bool
+    ) {
+        guard let presenter = findViewController() else { return }
+
+        let alert = UIAlertController(
+            title: "You can’t mention @everyone",
+            message: "You don’t have permission to mention @everyone in this channel. Please contact the server owner if you believe this is incorrect.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Edit Message", style: .cancel) { [weak self] _ in
+            self?.textView.becomeFirstResponder()
+        })
+        alert.addAction(UIAlertAction(title: "Send as Plain Text", style: .default) { [weak self] _ in
+            self?.performSend(text: text, hasAttachments: hasAttachments)
+        })
+        presenter.present(alert, animated: true)
+    }
+
+    private func performSend(text: String, hasAttachments: Bool) {
         
         if let editingMessage = editingMessage {
             // Handle edit message (attachments not supported for editing)

--- a/Revolt/ViewState+Extensions/ViewState+WebSocketEvents.swift
+++ b/Revolt/ViewState+Extensions/ViewState+WebSocketEvents.swift
@@ -199,9 +199,7 @@ extension ViewState {
                 members[member.id.server]?[member.id.user] = member
             }
             
-            let userMentioned = m.mentions?.contains(where: {
-                $0 == currentUser?.id
-            }) ?? false
+            let userMentioned = currentUser.map { m.mentionsUser($0.id) } ?? false
             
             // Check if message is from current user
             let isFromCurrentUser = m.author == currentUser?.id

--- a/RevoltTests/RevoltTests.swift
+++ b/RevoltTests/RevoltTests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 @testable import Revolt
+import Types
 
 final class RevoltTests: XCTestCase {
 
@@ -24,6 +25,76 @@ final class RevoltTests: XCTestCase {
         // Any test you write for XCTest can be annotated as throws and async.
         // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
         // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testMessageDecodesEveryoneFlagAndCombinesMentionSemantics() throws {
+        let everyoneJSON = Data(#"{"_id":"01TESTMESSAGE0000000000000","content":"@everyone","author":"author","channel":"channel","flags":2}"#.utf8)
+        let everyoneMessage = try JSONDecoder().decode(Types.Message.self, from: everyoneJSON)
+
+        XCTAssertTrue(everyoneMessage.mentionsEveryone)
+        XCTAssertTrue(everyoneMessage.mentionsUser("any-user"))
+
+        let directJSON = Data(#"{"_id":"01TESTMESSAGE0000000000001","author":"author","channel":"channel","mentions":["target"]}"#.utf8)
+        let directMessage = try JSONDecoder().decode(Types.Message.self, from: directJSON)
+
+        XCTAssertFalse(directMessage.mentionsEveryone)
+        XCTAssertTrue(directMessage.mentionsUser("target"))
+        XCTAssertFalse(directMessage.mentionsUser("other"))
+    }
+
+    func testMentionEveryonePermissionSurvivesOverwriteApplication() {
+        let granted = Types.Permissions.none.apply(
+            overwrite: Overwrite(a: .mentionEveryone, d: .none)
+        )
+        XCTAssertTrue(granted.contains(.mentionEveryone))
+        XCTAssertTrue(Types.Permissions.all.contains(.mentionEveryone))
+
+        let denied = granted.apply(
+            overwrite: Overwrite(a: .none, d: .mentionEveryone)
+        )
+        XCTAssertFalse(denied.contains(.mentionEveryone))
+    }
+
+    func testEveryoneSuggestionRequiresPermissionAndMatchingPrefix() {
+        XCTAssertTrue(MentionInputUtilities.shouldIncludeEveryone(searchText: "", canMentionEveryone: true))
+        XCTAssertTrue(MentionInputUtilities.shouldIncludeEveryone(searchText: "eve", canMentionEveryone: true))
+        XCTAssertTrue(MentionInputUtilities.shouldIncludeEveryone(searchText: "EVERYONE", canMentionEveryone: true))
+        XCTAssertFalse(MentionInputUtilities.shouldIncludeEveryone(searchText: "other", canMentionEveryone: true))
+        XCTAssertFalse(MentionInputUtilities.shouldIncludeEveryone(searchText: "eve", canMentionEveryone: false))
+    }
+
+    func testReplacingActiveMentionIsCursorAndUTF16Safe() throws {
+        let text = "😀 Hello @eve world"
+        let cursor = NSRange(location: ("😀 Hello @eve" as NSString).length, length: 0)
+        let replacement = try XCTUnwrap(MentionInputUtilities.replacingActiveMention(
+            in: text,
+            selectedRange: cursor,
+            with: "@everyone "
+        ))
+
+        XCTAssertEqual(replacement.text, "😀 Hello @everyone world")
+        XCTAssertEqual(
+            replacement.selectedRange.location,
+            ("😀 Hello @everyone " as NSString).length
+        )
+        XCTAssertEqual(
+            MentionInputUtilities.searchText(in: "before @eve after", selectedRange: NSRange(location: 11, length: 0)),
+            "eve"
+        )
+        XCTAssertNil(MentionInputUtilities.replacingActiveMention(
+            in: text,
+            selectedRange: NSRange(location: NSNotFound, length: 0),
+            with: "@everyone "
+        ))
+    }
+
+    func testEveryoneMentionRangesExcludeEscapesAndCode() {
+        let text = "@everyone \\@everyone `@everyone` ```swift\n@everyone\n``` end @everyone"
+        let ranges = MentionInputUtilities.everyoneMentionRanges(in: text)
+        let nsText = text as NSString
+
+        XCTAssertEqual(ranges.count, 2)
+        XCTAssertEqual(ranges.map { nsText.substring(with: $0) }, ["@everyone", "@everyone"])
     }
 
     func testPerformanceExample() throws {

--- a/RevoltTests/RevoltTests.swift
+++ b/RevoltTests/RevoltTests.swift
@@ -97,6 +97,56 @@ final class RevoltTests: XCTestCase {
         XCTAssertEqual(ranges.map { nsText.substring(with: $0) }, ["@everyone", "@everyone"])
     }
 
+    func testSingleImagePreviewPreservesAspectRatioWithinCaps() {
+        let portrait = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: CGSize(width: 1080, height: 1440),
+            availableWidth: 311
+        )
+        XCTAssertEqual(portrait.width, 240, accuracy: 0.01)
+        XCTAssertEqual(portrait.height, 320, accuracy: 0.01)
+
+        let landscape = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: CGSize(width: 1600, height: 900),
+            availableWidth: 311
+        )
+        XCTAssertEqual(landscape.width, 280, accuracy: 0.01)
+        XCTAssertEqual(landscape.height, 157.5, accuracy: 0.01)
+
+        let veryTall = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: CGSize(width: 1000, height: 4000),
+            availableWidth: 311
+        )
+        XCTAssertEqual(veryTall.width, 80, accuracy: 0.01)
+        XCTAssertEqual(veryTall.height, 320, accuracy: 0.01)
+    }
+
+    func testImagePreviewLayoutHandlesNarrowWidthsAndMissingMetadata() {
+        let narrow = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: CGSize(width: 1200, height: 1600),
+            availableWidth: 200
+        )
+        XCTAssertEqual(narrow.width, 200, accuracy: 0.01)
+        XCTAssertEqual(narrow.height, 266.67, accuracy: 0.01)
+
+        let fallback = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: nil,
+            availableWidth: 311
+        )
+        XCTAssertEqual(fallback.width, 280, accuracy: 0.01)
+        XCTAssertEqual(fallback.height, 210, accuracy: 0.01)
+    }
+
+    func testGalleryPreviewUsesSquareTilesAndStableRowHeight() {
+        let tile = ImageAttachmentPreviewLayout.galleryTileSize(availableWidth: 311)
+        XCTAssertEqual(tile.width, 150, accuracy: 0.01)
+        XCTAssertEqual(tile.height, 150, accuracy: 0.01)
+        XCTAssertEqual(
+            ImageAttachmentPreviewLayout.galleryHeight(imageCount: 5, tileHeight: tile.height),
+            466,
+            accuracy: 0.01
+        )
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {

--- a/RevoltTests/RevoltTests.swift
+++ b/RevoltTests/RevoltTests.swift
@@ -211,6 +211,49 @@ final class RevoltTests: XCTestCase {
         )
     }
 
+    func testFullScreenGalleryNavigationMovesOneImageAndStopsAtBounds() {
+        XCTAssertEqual(
+            FullScreenImageGalleryNavigation.destinationIndex(
+                currentIndex: 1,
+                itemCount: 4,
+                step: 1
+            ),
+            2
+        )
+        XCTAssertEqual(
+            FullScreenImageGalleryNavigation.destinationIndex(
+                currentIndex: 2,
+                itemCount: 4,
+                step: -1
+            ),
+            1
+        )
+        XCTAssertNil(
+            FullScreenImageGalleryNavigation.destinationIndex(
+                currentIndex: 0,
+                itemCount: 4,
+                step: -1
+            )
+        )
+        XCTAssertNil(
+            FullScreenImageGalleryNavigation.destinationIndex(
+                currentIndex: 3,
+                itemCount: 4,
+                step: 1
+            )
+        )
+    }
+
+    func testFullScreenGalleryPositionTextOnlyAppearsForMultipleImages() {
+        XCTAssertEqual(
+            FullScreenImageGalleryNavigation.positionText(currentIndex: 1, itemCount: 4),
+            "2 of 4"
+        )
+        XCTAssertNil(
+            FullScreenImageGalleryNavigation.positionText(currentIndex: 0, itemCount: 1)
+        )
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {

--- a/RevoltTests/RevoltTests.swift
+++ b/RevoltTests/RevoltTests.swift
@@ -97,6 +97,24 @@ final class RevoltTests: XCTestCase {
         XCTAssertEqual(ranges.map { nsText.substring(with: $0) }, ["@everyone", "@everyone"])
     }
 
+    func testUserMentionTokensResolveNumericAndULIDIdentifiers() {
+        let text = "Hi <@1297812287981359106> and <@01TESTUSER000000000000000>"
+        let resolved = text.replacingUserMentionTokens { userId in
+            userId == "01TESTUSER000000000000000" ? "Akshat" : nil
+        }
+
+        XCTAssertEqual(resolved, "Hi @unknown-user and @Akshat")
+        XCTAssertFalse(resolved.contains("<@"))
+    }
+
+    func testUserMentionFallbackNeverLeaksRawIdentifier() {
+        let rawMention = "<@1297812287981359106>"
+        XCTAssertEqual(
+            rawMention.replacingUserMentionTokens { _ in nil },
+            "@unknown-user"
+        )
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {

--- a/RevoltTests/RevoltTests.swift
+++ b/RevoltTests/RevoltTests.swift
@@ -147,6 +147,33 @@ final class RevoltTests: XCTestCase {
         )
     }
 
+    func testThreeImageGalleryUsesLargeLeadingTileAndStackedTrailingTiles() {
+        let tile = CGSize(width: 150, height: 150)
+        let frames = (0..<3).map {
+            ImageAttachmentPreviewLayout.galleryFrame(
+                index: $0,
+                imageCount: 3,
+                tileSize: tile
+            )
+        }
+
+        XCTAssertEqual(frames[0], CGRect(x: 0, y: 0, width: 150, height: 308))
+        XCTAssertEqual(frames[1], CGRect(x: 158, y: 0, width: 150, height: 150))
+        XCTAssertEqual(frames[2], CGRect(x: 158, y: 158, width: 150, height: 150))
+    }
+
+    func testEvenImageGalleryKeepsTwoColumnGrid() {
+        let tile = CGSize(width: 150, height: 150)
+        XCTAssertEqual(
+            ImageAttachmentPreviewLayout.galleryFrame(
+                index: 3,
+                imageCount: 4,
+                tileSize: tile
+            ),
+            CGRect(x: 158, y: 158, width: 150, height: 150)
+        )
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {

--- a/RevoltTests/RevoltTests.swift
+++ b/RevoltTests/RevoltTests.swift
@@ -63,6 +63,25 @@ final class RevoltTests: XCTestCase {
         XCTAssertFalse(MentionInputUtilities.shouldIncludeEveryone(searchText: "eve", canMentionEveryone: false))
     }
 
+    func testUnauthorizedEveryoneRequiresPlainTextConfirmation() {
+        XCTAssertTrue(MentionInputUtilities.requiresPlainTextEveryoneConfirmation(
+            text: "Please review, @everyone",
+            canMentionEveryone: false
+        ))
+        XCTAssertFalse(MentionInputUtilities.requiresPlainTextEveryoneConfirmation(
+            text: "Please review, @everyone",
+            canMentionEveryone: true
+        ))
+        XCTAssertFalse(MentionInputUtilities.requiresPlainTextEveryoneConfirmation(
+            text: #"Send \@everyone and `@everyone` literally"#,
+            canMentionEveryone: false
+        ))
+        XCTAssertFalse(MentionInputUtilities.requiresPlainTextEveryoneConfirmation(
+            text: "No mass mention here",
+            canMentionEveryone: false
+        ))
+    }
+
     func testReplacingActiveMentionIsCursorAndUTF16Safe() throws {
         let text = "😀 Hello @eve world"
         let cursor = NSRange(location: ("😀 Hello @eve" as NSString).length, length: 0)

--- a/Types/Message.swift
+++ b/Types/Message.swift
@@ -236,7 +236,7 @@ public struct Message: Identifiable, Codable, Equatable {
     ///   - webhook: The webhook information (optional).
     ///   - nonce: Client-provided nonce echoed by server for deduplication (optional).
     ///   - pinned: Defines whether the message is pinned or not
-    public init(id: String, content: String? = nil, author: String, channel: String, system: SystemMessageContent? = nil, attachments: [File]? = nil, mentions: [String]? = nil, replies: [String]? = nil, edited: String? = nil, masquerade: Masquerade? = nil, interactions: Interactions? = nil, reactions: [String: [String]]? = nil, user: User? = nil, member: Member? = nil, embeds: [Embed]? = nil, webhook: MessageWebhook? = nil, nonce: String? = nil, pinned: Bool? = nil ) {
+    public init(id: String, content: String? = nil, author: String, channel: String, system: SystemMessageContent? = nil, attachments: [File]? = nil, mentions: [String]? = nil, replies: [String]? = nil, edited: String? = nil, masquerade: Masquerade? = nil, interactions: Interactions? = nil, reactions: [String: [String]]? = nil, user: User? = nil, member: Member? = nil, embeds: [Embed]? = nil, webhook: MessageWebhook? = nil, nonce: String? = nil, pinned: Bool? = nil, flags: Int? = nil) {
         self.id = id // Initialize the message ID.
         self.content = content // Set the message content (if any).
         self.author = author // Set the author ID.
@@ -255,6 +255,7 @@ public struct Message: Identifiable, Codable, Equatable {
         self.webhook = webhook // Set the webhook information (if any).
         self.nonce = nonce // Set the nonce (if echoed by server).
         self.pinned = pinned // Set the pinned (if any).
+        self.flags = flags
     }
     
     public var id: String // Unique identifier for the message.
@@ -276,10 +277,21 @@ public struct Message: Identifiable, Codable, Equatable {
     public var webhook: MessageWebhook? // The webhook information (if any).
     public var nonce: String? // Client-provided nonce echoed by server for deduplication (optional).
     public var pinned: Bool?
+    public var flags: Int?
+
+    /// Whether the server recognized this message as an `@everyone` mention.
+    public var mentionsEveryone: Bool {
+        ((flags ?? 0) & 2) == 2
+    }
+
+    /// Whether this message should be treated as mentioning a specific user.
+    public func mentionsUser(_ userId: String) -> Bool {
+        mentions?.contains(userId) == true || mentionsEveryone
+    }
     
     enum CodingKeys: String, CodingKey {
         case id = "_id" // Mapping the ID to the JSON key "_id".
-        case content, author, channel, system, attachments, mentions, replies, edited, masquerade, interactions, reactions, user, member, embeds, webhook, nonce, pinned // Other properties mapped directly.
+        case content, author, channel, system, attachments, mentions, replies, edited, masquerade, interactions, reactions, user, member, embeds, webhook, nonce, pinned, flags // Other properties mapped directly.
     }
     
     public func isInviteLink() -> Bool {

--- a/Types/Permissions.swift
+++ b/Types/Permissions.swift
@@ -84,13 +84,15 @@ public struct Permissions: OptionSet, Hashable {
     public static let muteMembers = Permissions(rawValue: 1 << 33) // Permission to mute members
     public static let deafenMembers = Permissions(rawValue: 1 << 34) // Permission to deafen members
     public static let moveMembers = Permissions(rawValue: 1 << 35) // Permission to move members between channels
+    public static let mentionEveryone = Permissions(rawValue: 1 << 36) // Permission to mention everyone in a channel
     
     // Convenience properties for default permissions
     public static let all = Permissions(arrayLiteral: [
         .manageChannel, .manageServer, .managePermissions, .manageRole, .manageCustomisation, .kickMembers, .banMembers,
         .timeoutMembers, .assignRoles, .manageNickname, .changeNicknames, .changeAvatars, .removeAvatars, .viewChannel,
         .readMessageHistory, .sendMessages, .manageMessages, .manageWebhooks, .inviteOthers, .sendEmbeds,
-        .uploadFiles, .masquerade, .react, .connect, .speak, .video, .muteMembers, .deafenMembers, .moveMembers
+        .uploadFiles, .masquerade, .react, .connect, .speak, .video, .muteMembers, .deafenMembers, .moveMembers,
+        .mentionEveryone
     ])
     
     public static let defaultViewOnly = Permissions([.viewChannel, .readMessageHistory]) // Default view-only permissions
@@ -150,6 +152,7 @@ public struct Permissions: OptionSet, Hashable {
             case .muteMembers: return "Mute Members"
             case .deafenMembers: return "Deafen Members"
             case .moveMembers: return "Move Members"
+            case .mentionEveryone: return "Mention Everyone"
             default: return "Unknown"
         }
     }
@@ -186,6 +189,7 @@ public struct Permissions: OptionSet, Hashable {
             case .muteMembers: return "Allows members to mute others in a voice channel."
             case .deafenMembers: return "Allows members to deafen others in a voice channel."
             case .moveMembers: return "Allows members to move others between voice channels."
+            case .mentionEveryone: return "Allows members to mention everyone in a channel."
             default: return "Unknown"
         }
     }


### PR DESCRIPTION
## Summary

- add a permission-aware `@everyone` autocomplete entry for server channels and group DMs
- replace the active mention at the cursor using UTF-16-safe ranges and preserve mention-token offsets
- decode the server's message flag and use it for semantic rendering and unread mention handling
- highlight only server-recognized `@everyone` messages in chat
- intercept unauthorized semantic `@everyone` sends with one clear confirmation dialog
- preserve the composer on **Edit Message** and provide a one-time **Send as Plain Text** action
- document reusable, Keychain-backed QA accounts without committing passwords

## Why

iOS previously treated only explicit user IDs as mentions. It neither exposed the server's `MentionEveryone` permission nor decoded message flag `2`, so mass mentions could not be selected reliably, highlighted semantically, or counted as unread mentions.

The server intentionally converts an unauthorized `@everyone` into plain text. Without client feedback, that looked like a broken mention. The composer now explains the missing permission before sending and lets the user either keep editing or explicitly send the text unchanged.

## Validation

- `swiftc -parse RevoltTests/RevoltTests.swift`
- `xcodebuild -workspace Revolt.xcworkspace -scheme Revolt -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' SWIFT_VERSION=5 build`
- decision coverage for permitted, unauthorized, escaped, inline-code, and ordinary-text cases
- Archem production QA: permitted sender produced `flags: 2`; denied sender's literal text had no flag
- recipient unread sync contained permitted messages and excluded the denied literal
- simulator UI: permitted autocomplete, insertion, send, and highlight passed
- simulator UI: denied account did not receive the `everyone` suggestion
- simulator UI: unauthorized send displayed the permission explanation and both actions
- simulator UI: **Edit Message** preserved the exact composer text
- simulator UI: **Send as Plain Text** sent exactly one plain message and cleared the composer

The test target is not configured in the shared scheme, so the added XCTest source was syntax-checked and the app target was fully compiled. Updated simulator evidence was shared with Akshat in the `#zeko-ios` review thread.