### PR TITLE
Improve image attachment previews

### DIFF
--- a/Revolt/Components/MessageRenderer/MessageAttachment.swift
+++ b/Revolt/Components/MessageRenderer/MessageAttachment.swift
@@ -75,6 +75,7 @@ struct MessageAttachment: View {
     @State var isPresented: Bool = false
     var attachment: File  // The file attachment to be displayed
     var height : CGFloat = 0
+    var usesAdaptiveSingleImageLayout = false
     
     
     var body: some View {
@@ -82,12 +83,29 @@ struct MessageAttachment: View {
         
         Group {
             switch attachment.metadata {
-            case .image(_):  // Handle image attachments
-                
-                
-                /*Button {
-                    self.isPresented.toggle()
-                } label: {*/
+            case .image(let metadata):  // Handle image attachments
+                if usesAdaptiveSingleImageLayout {
+                    let availableWidth = max(1, UIScreen.main.bounds.width - 82)
+                    let previewSize = ImageAttachmentPreviewLayout.singleSize(
+                        sourceSize: CGSize(
+                            width: CGFloat(metadata.width),
+                            height: CGFloat(metadata.height)
+                        ),
+                        availableWidth: availableWidth
+                    )
+
+                    LazyImage(
+                        source: .file(attachment),
+                        clipTo: RoundedRectangle(cornerRadius: .radiusXSmall),
+                        contentMode: .fit
+                    )
+                    .frame(width: previewSize.width, height: previewSize.height)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .onTapGesture {
+                        self.isPresented.toggle()
+                    }
+                } else {
                     Color.clear
                         .overlay {
                             LazyImage(source: .file(attachment),
@@ -103,12 +121,7 @@ struct MessageAttachment: View {
                         .onTapGesture{
                             self.isPresented.toggle()
                         }
-               // }
-                
-                
-                
-                
-                
+                }
             case .video(_):  // Handle video attachments (same UIKit player as chat)
                 let videoURL = viewState.formatUrl(fromId: attachment.id, withTag: "attachments")
                 ChannelVideoAttachmentPlayerView(
@@ -221,9 +234,6 @@ struct ZoomableMessageAttachment : View {
                         .aspectRatio(contentMode: .fit)  // Maintain aspect ratio
                         .frame(maxHeight: 295)  // Set a maximum height for the image
                     }
-                    
-                    
-                   
                     
                     
                 case .video(_):  // Handle video attachments (same UIKit player as chat)

--- a/Revolt/Components/MessageRenderer/MessageContentsView.swift
+++ b/Revolt/Components/MessageRenderer/MessageContentsView.swift
@@ -265,7 +265,11 @@ struct MessageContentsView: View {
                                 if !mediaAttachments.isEmpty {
                                     
                                     if mediaAttachments.count == 1 {
-                                        MessageAttachment(attachment: mediaAttachments[0], height: 295)
+                                        MessageAttachment(
+                                            attachment: mediaAttachments[0],
+                                            height: 295,
+                                            usesAdaptiveSingleImageLayout: true
+                                        )
                                             .padding(.top, .padding4)
                                     } else if mediaAttachments.count == 2 {
                                         

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Attachments.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Attachments.swift
@@ -47,6 +47,45 @@ struct ImageAttachmentPreviewLayout {
         return CGFloat(rowCount) * tileHeight
             + CGFloat(max(0, rowCount - 1)) * gallerySpacing
     }
+
+    static func galleryFrame(index: Int, imageCount: Int, tileSize: CGSize) -> CGRect {
+        guard index >= 0, index < imageCount else { return .zero }
+
+        if imageCount == 3 {
+            switch index {
+            case 0:
+                return CGRect(
+                    x: 0,
+                    y: 0,
+                    width: tileSize.width,
+                    height: tileSize.height * 2 + gallerySpacing
+                )
+            case 1:
+                return CGRect(
+                    x: tileSize.width + gallerySpacing,
+                    y: 0,
+                    width: tileSize.width,
+                    height: tileSize.height
+                )
+            default:
+                return CGRect(
+                    x: tileSize.width + gallerySpacing,
+                    y: tileSize.height + gallerySpacing,
+                    width: tileSize.width,
+                    height: tileSize.height
+                )
+            }
+        }
+
+        let column = index % 2
+        let row = index / 2
+        return CGRect(
+            x: CGFloat(column) * (tileSize.width + gallerySpacing),
+            y: CGFloat(row) * (tileSize.height + gallerySpacing),
+            width: tileSize.width,
+            height: tileSize.height
+        )
+    }
 }
 
 extension MessageCell {
@@ -140,8 +179,6 @@ extension MessageCell {
         // // print("🖼️ Setting up image attachments constraints - spacing: 20px")
         
         // Calculate available width first - needed for constraints
-        let maxImagesPerRow = 2
-        let imageSpacing = ImageAttachmentPreviewLayout.gallerySpacing
         // Calculate available width based on actual layout constraints
         // Account for: avatar leading (16) + avatar width (40) + avatar spacing (10) + content trailing margin (16)
         let totalMargins: CGFloat = 16 + 40 + 10 + 16 // Total: 82px
@@ -192,10 +229,6 @@ extension MessageCell {
         containerHeightConstraint.priority = UILayoutPriority.defaultHigh
         containerHeightConstraint.isActive = true
         
-        var currentX: CGFloat = 0
-        var currentY: CGFloat = 0
-        var imagesInCurrentRow = 0
-        
         for (index, attachment) in attachments.enumerated() {
             let attachmentId = attachment.id
             // Create image view for this attachment
@@ -216,28 +249,26 @@ extension MessageCell {
             imageAttachmentsContainer!.addSubview(imageView)
             imageAttachmentViews.append(imageView)
             
-            // Calculate position
-            let previewSize = isGallery ? galleryTileSize : singlePreviewSize
-            if imagesInCurrentRow >= maxImagesPerRow || (currentX + previewSize.width > availableWidth) {
-                // Move to next row if we've hit the max images per row OR if the next image would overflow
-                currentX = 0
-                currentY += galleryTileSize.height + imageSpacing
-                imagesInCurrentRow = 0
-            }
-
-            let remainingWidth = availableWidth - currentX
-            let actualImageWidth = min(previewSize.width, remainingWidth)
+            let previewFrame = isGallery
+                ? ImageAttachmentPreviewLayout.galleryFrame(
+                    index: index,
+                    imageCount: attachments.count,
+                    tileSize: galleryTileSize
+                )
+                : CGRect(origin: .zero, size: singlePreviewSize)
+            let remainingWidth = availableWidth - previewFrame.minX
+            let actualImageWidth = min(previewFrame.width, remainingWidth)
             
             // Create width constraint with lower priority to prevent conflicts
             let widthConstraint = imageView.widthAnchor.constraint(equalToConstant: actualImageWidth)
             widthConstraint.priority = UILayoutPriority(999) // High but not required
             let imageHeightConstraint = imageView.heightAnchor.constraint(
-                equalToConstant: previewSize.height
+                equalToConstant: previewFrame.height
             )
             
             NSLayoutConstraint.activate([
-                imageView.leadingAnchor.constraint(equalTo: imageAttachmentsContainer!.leadingAnchor, constant: currentX),
-                imageView.topAnchor.constraint(equalTo: imageAttachmentsContainer!.topAnchor, constant: currentY),
+                imageView.leadingAnchor.constraint(equalTo: imageAttachmentsContainer!.leadingAnchor, constant: previewFrame.minX),
+                imageView.topAnchor.constraint(equalTo: imageAttachmentsContainer!.topAnchor, constant: previewFrame.minY),
                 widthConstraint,
                 imageHeightConstraint,
                 // Add trailing constraint to ensure image doesn't exceed container bounds - this is the critical constraint
@@ -266,7 +297,7 @@ extension MessageCell {
             } else {
                 // For real messages, load from server using Kingfisher
                 if let url = URL(string: viewState.formatUrl(fromId: attachmentId, withTag: "attachments")) {
-                    let downsampleSize = previewSize
+                    let downsampleSize = previewFrame.size
                     imageView.kf.setImage(
                         with: url,
                         placeholder: UIImage(systemName: "photo"),
@@ -318,9 +349,6 @@ extension MessageCell {
                 }
             }
             
-            // Update position for next image
-            currentX += actualImageWidth + imageSpacing
-            imagesInCurrentRow += 1
         }
     }
 

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Attachments.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Attachments.swift
@@ -10,8 +10,47 @@ import Types
 import Kingfisher
 import AVKit
 
+struct ImageAttachmentPreviewLayout {
+    static let singleMaxWidth: CGFloat = 280
+    static let singleMaxHeight: CGFloat = 320
+    static let galleryMaxTileWidth: CGFloat = 150
+    static let gallerySpacing: CGFloat = 8
+
+    static func singleSize(sourceSize: CGSize?, availableWidth: CGFloat) -> CGSize {
+        let maxWidth = max(1, min(availableWidth, singleMaxWidth))
+        let fallback = CGSize(width: maxWidth, height: maxWidth * 0.75)
+
+        guard let sourceSize,
+              sourceSize.width > 0,
+              sourceSize.height > 0 else {
+            return fallback
+        }
+
+        let scale = min(maxWidth / sourceSize.width, singleMaxHeight / sourceSize.height)
+        return CGSize(
+            width: max(1, sourceSize.width * scale),
+            height: max(1, sourceSize.height * scale)
+        )
+    }
+
+    static func galleryTileSize(availableWidth: CGFloat) -> CGSize {
+        let width = max(
+            1,
+            min((availableWidth - gallerySpacing) / 2, galleryMaxTileWidth)
+        )
+        return CGSize(width: width, height: width)
+    }
+
+    static func galleryHeight(imageCount: Int, tileHeight: CGFloat) -> CGFloat {
+        guard imageCount > 0 else { return 0 }
+        let rowCount = (imageCount + 1) / 2
+        return CGFloat(rowCount) * tileHeight
+            + CGFloat(max(0, rowCount - 1)) * gallerySpacing
+    }
+}
+
 extension MessageCell {
-    internal func loadImageAttachments(attachments: [String], viewState: ViewState) {
+    internal func loadImageAttachments(attachments: [Types.File], viewState: ViewState) {
         guard !attachments.isEmpty else {
             // If no attachments, remove any existing container
             imageAttachmentsContainer?.removeFromSuperview()
@@ -69,6 +108,7 @@ extension MessageCell {
         let spacerView = contentView.viewWithTag(1001)!
         
         // Clear any existing constraints for the container
+        NSLayoutConstraint.deactivate(imageAttachmentsContainer!.constraints)
         for constraint in contentView.constraints {
             if constraint.firstItem === imageAttachmentsContainer ||
                constraint.secondItem === imageAttachmentsContainer {
@@ -101,11 +141,12 @@ extension MessageCell {
         
         // Calculate available width first - needed for constraints
         let maxImagesPerRow = 2
-        let imageSpacing: CGFloat = 8
+        let imageSpacing = ImageAttachmentPreviewLayout.gallerySpacing
         // Calculate available width based on actual layout constraints
         // Account for: avatar leading (16) + avatar width (40) + avatar spacing (10) + content trailing margin (16)
         let totalMargins: CGFloat = 16 + 40 + 10 + 16 // Total: 82px
-        let availableWidth = UIScreen.main.bounds.width - totalMargins
+        let measuredWidth = window?.bounds.width ?? UIScreen.main.bounds.width
+        let availableWidth = measuredWidth - totalMargins
         
         // Add a maximum width constraint to prevent overflow - use lower priority to avoid conflicts
         let maxWidthConstraint = imageAttachmentsContainer!.widthAnchor.constraint(lessThanOrEqualToConstant: availableWidth)
@@ -130,24 +171,40 @@ extension MessageCell {
             maxWidthConstraint
         ])
         
-        // Create image views for each attachment
-        let finalImageWidth: CGFloat = attachments.count == 1 ? min(availableWidth * 0.7, 220) : min((availableWidth - imageSpacing) / 2, 150)
-        let imageHeight: CGFloat = attachments.count == 1 ? min(finalImageWidth * 0.75, 165) : min(finalImageWidth * 0.75, 110)
-        
-        // print("🖼️ Calculated sizes - Image width: \(finalImageWidth), Image height: \(imageHeight), Available width: \(availableWidth), Screen width: \(UIScreen.main.bounds.width)")
+        let isGallery = attachments.count > 1
+        let galleryTileSize = ImageAttachmentPreviewLayout.galleryTileSize(availableWidth: availableWidth)
+        let singleSourceSize = attachments.first.flatMap {
+            imageSourceSize(for: $0, viewState: viewState)
+        }
+        let singlePreviewSize = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: singleSourceSize,
+            availableWidth: availableWidth
+        )
+        let initialContainerHeight = isGallery
+            ? ImageAttachmentPreviewLayout.galleryHeight(
+                imageCount: attachments.count,
+                tileHeight: galleryTileSize.height
+            )
+            : singlePreviewSize.height
+        let containerHeightConstraint = imageAttachmentsContainer!.heightAnchor.constraint(
+            equalToConstant: initialContainerHeight
+        )
+        containerHeightConstraint.priority = UILayoutPriority.defaultHigh
+        containerHeightConstraint.isActive = true
         
         var currentX: CGFloat = 0
         var currentY: CGFloat = 0
         var imagesInCurrentRow = 0
         
-        for (index, attachmentId) in attachments.enumerated() {
+        for (index, attachment) in attachments.enumerated() {
+            let attachmentId = attachment.id
             // Create image view for this attachment
             let imageView = UIImageView()
             imageView.translatesAutoresizingMaskIntoConstraints = false
-            imageView.contentMode = .scaleAspectFit // Show entire image, preserve aspect ratio
+            imageView.contentMode = .scaleAspectFit
             imageView.clipsToBounds = true
             imageView.layer.cornerRadius = 8
-            imageView.backgroundColor = UIColor.gray.withAlphaComponent(0.1) // Lighter background
+            imageView.backgroundColor = UIColor.gray.withAlphaComponent(0.1)
             imageView.isUserInteractionEnabled = true
             imageView.tag = index // Store index for tap handling
             imageView.accessibilityIdentifier = attachmentId
@@ -160,30 +217,29 @@ extension MessageCell {
             imageAttachmentViews.append(imageView)
             
             // Calculate position
-            if imagesInCurrentRow >= maxImagesPerRow || (currentX + finalImageWidth > availableWidth) {
+            let previewSize = isGallery ? galleryTileSize : singlePreviewSize
+            if imagesInCurrentRow >= maxImagesPerRow || (currentX + previewSize.width > availableWidth) {
                 // Move to next row if we've hit the max images per row OR if the next image would overflow
                 currentX = 0
-                let rowImageHeight = min(finalImageWidth * 0.75, 165) // Match the updated max height
-                currentY += rowImageHeight + 10 // Match container calculation
+                currentY += galleryTileSize.height + imageSpacing
                 imagesInCurrentRow = 0
             }
-            
-            // Set up simple constraints for this image
-            let imageViewHeight = min(finalImageWidth * 0.75, 165) // Match container calculation with updated max height
-            
-            // Ensure the image width doesn't exceed the remaining space in the container
+
             let remainingWidth = availableWidth - currentX
-            let actualImageWidth = min(finalImageWidth, remainingWidth)
+            let actualImageWidth = min(previewSize.width, remainingWidth)
             
             // Create width constraint with lower priority to prevent conflicts
             let widthConstraint = imageView.widthAnchor.constraint(equalToConstant: actualImageWidth)
             widthConstraint.priority = UILayoutPriority(999) // High but not required
+            let imageHeightConstraint = imageView.heightAnchor.constraint(
+                equalToConstant: previewSize.height
+            )
             
             NSLayoutConstraint.activate([
                 imageView.leadingAnchor.constraint(equalTo: imageAttachmentsContainer!.leadingAnchor, constant: currentX),
                 imageView.topAnchor.constraint(equalTo: imageAttachmentsContainer!.topAnchor, constant: currentY),
                 widthConstraint,
-                imageView.heightAnchor.constraint(equalToConstant: imageViewHeight),
+                imageHeightConstraint,
                 // Add trailing constraint to ensure image doesn't exceed container bounds - this is the critical constraint
                 imageView.trailingAnchor.constraint(lessThanOrEqualTo: imageAttachmentsContainer!.trailingAnchor)
             ])
@@ -198,6 +254,8 @@ extension MessageCell {
                 // For pending messages, show local image data with loading overlay
                 if let localImage = UIImage(data: localImageData) {
                     imageView.image = localImage
+                    imageView.backgroundColor = .clear
+                    imageView.contentMode = isGallery ? .scaleAspectFill : .scaleAspectFit
                     
                     // Add loading overlay to show upload progress
                     addLoadingOverlayToImageView(imageView, attachmentId: attachmentId, queuedMessage: queuedMessage)
@@ -208,7 +266,7 @@ extension MessageCell {
             } else {
                 // For real messages, load from server using Kingfisher
                 if let url = URL(string: viewState.formatUrl(fromId: attachmentId, withTag: "attachments")) {
-                    let downsampleSize = CGSize(width: finalImageWidth, height: imageHeight)
+                    let downsampleSize = previewSize
                     imageView.kf.setImage(
                         with: url,
                         placeholder: UIImage(systemName: "photo"),
@@ -221,11 +279,22 @@ extension MessageCell {
                         ],
                         completionHandler: { [weak self] result in
                             switch result {
-                            case .success(_):
+                            case .success(let value):
                                 // Ensure cell hasn't been reused for a different message
                                 if let currentAttachments = self?.currentMessage?.attachments,
                                    currentAttachments.contains(where: { $0.id == attachmentId }) {
-                                    // Success: keep the loaded image
+                                    imageView.backgroundColor = .clear
+                                    imageView.contentMode = isGallery ? .scaleAspectFill : .scaleAspectFit
+
+                                    if !isGallery, singleSourceSize == nil {
+                                        let fittedSize = ImageAttachmentPreviewLayout.singleSize(
+                                            sourceSize: value.image.size,
+                                            availableWidth: availableWidth
+                                        )
+                                        widthConstraint.constant = fittedSize.width
+                                        imageHeightConstraint.constant = fittedSize.height
+                                        containerHeightConstraint.constant = fittedSize.height
+                                    }
 
                                     // Force layout update to ensure proper positioning
                                     self?.contentView.setNeedsLayout()
@@ -253,18 +322,27 @@ extension MessageCell {
             currentX += actualImageWidth + imageSpacing
             imagesInCurrentRow += 1
         }
-        
-        // Calculate exact container height based on actual image layout
-        let numberOfRows = (attachments.count + maxImagesPerRow - 1) / maxImagesPerRow
-        let containerImageHeight: CGFloat = min(finalImageWidth * 0.75, 165) // Updated max height to match image constraints
-        let totalHeight = CGFloat(numberOfRows) * containerImageHeight + CGFloat(max(0, numberOfRows - 1)) * 10 // 10px spacing between rows
-        
-        let heightConstraint = imageAttachmentsContainer!.heightAnchor.constraint(equalToConstant: totalHeight)
-        heightConstraint.priority = UILayoutPriority.defaultHigh // Lower priority to prevent conflicts
-        heightConstraint.isActive = true
-        
-        // // print("🖼️ Set fixed container height: \(totalHeight) for \(numberOfRows) rows")
-        // // print("🖼️ Image details - Width: \(finalImageWidth), Height: \(containerImageHeight), Attachments: \(attachments.count)")
+    }
+
+    private func imageSourceSize(for attachment: Types.File, viewState: ViewState) -> CGSize? {
+        if case .image(let metadata) = attachment.metadata,
+           metadata.width > 0,
+           metadata.height > 0 {
+            return CGSize(width: CGFloat(metadata.width), height: CGFloat(metadata.height))
+        }
+
+        guard isPendingMessage,
+              let currentMessage,
+              let channelQueuedMessages = viewState.queuedMessages[currentMessage.channel],
+              let queuedMessage = channelQueuedMessages.first(where: { $0.nonce == currentMessage.id }),
+              let localImageData = queuedMessage.attachmentData.first(where: {
+                  $0.1.contains(attachment.id.replacingOccurrences(of: "\(queuedMessage.nonce)_", with: ""))
+              })?.0,
+              let image = UIImage(data: localImageData) else {
+            return nil
+        }
+
+        return image.size
     }
     
     internal func loadFileAttachments(attachments: [Types.File], viewState: ViewState) {

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
@@ -1884,8 +1884,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         
         // Load image attachments
         if !imageAttachments.isEmpty {
-            let imageIds = imageAttachments.map { $0.id }
-            loadImageAttachments(attachments: imageIds, viewState: viewState)
+            loadImageAttachments(attachments: imageAttachments, viewState: viewState)
         }
         
         // Load file attachments

--- a/RevoltTests/RevoltTests.swift
+++ b/RevoltTests/RevoltTests.swift
@@ -97,6 +97,56 @@ final class RevoltTests: XCTestCase {
         XCTAssertEqual(ranges.map { nsText.substring(with: $0) }, ["@everyone", "@everyone"])
     }
 
+    func testSingleImagePreviewPreservesAspectRatioWithinCaps() {
+        let portrait = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: CGSize(width: 1080, height: 1440),
+            availableWidth: 311
+        )
+        XCTAssertEqual(portrait.width, 240, accuracy: 0.01)
+        XCTAssertEqual(portrait.height, 320, accuracy: 0.01)
+
+        let landscape = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: CGSize(width: 1600, height: 900),
+            availableWidth: 311
+        )
+        XCTAssertEqual(landscape.width, 280, accuracy: 0.01)
+        XCTAssertEqual(landscape.height, 157.5, accuracy: 0.01)
+
+        let veryTall = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: CGSize(width: 1000, height: 4000),
+            availableWidth: 311
+        )
+        XCTAssertEqual(veryTall.width, 80, accuracy: 0.01)
+        XCTAssertEqual(veryTall.height, 320, accuracy: 0.01)
+    }
+
+    func testImagePreviewLayoutHandlesNarrowWidthsAndMissingMetadata() {
+        let narrow = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: CGSize(width: 1200, height: 1600),
+            availableWidth: 200
+        )
+        XCTAssertEqual(narrow.width, 200, accuracy: 0.01)
+        XCTAssertEqual(narrow.height, 266.67, accuracy: 0.01)
+
+        let fallback = ImageAttachmentPreviewLayout.singleSize(
+            sourceSize: nil,
+            availableWidth: 311
+        )
+        XCTAssertEqual(fallback.width, 280, accuracy: 0.01)
+        XCTAssertEqual(fallback.height, 210, accuracy: 0.01)
+    }
+
+    func testGalleryPreviewUsesSquareTilesAndStableRowHeight() {
+        let tile = ImageAttachmentPreviewLayout.galleryTileSize(availableWidth: 311)
+        XCTAssertEqual(tile.width, 150, accuracy: 0.01)
+        XCTAssertEqual(tile.height, 150, accuracy: 0.01)
+        XCTAssertEqual(
+            ImageAttachmentPreviewLayout.galleryHeight(imageCount: 5, tileHeight: tile.height),
+            466,
+            accuracy: 0.01
+        )
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {

--- a/RevoltTests/RevoltTests.swift
+++ b/RevoltTests/RevoltTests.swift
@@ -147,6 +147,33 @@ final class RevoltTests: XCTestCase {
         )
     }
 
+    func testThreeImageGalleryUsesLargeLeadingTileAndStackedTrailingTiles() {
+        let tile = CGSize(width: 150, height: 150)
+        let frames = (0..<3).map {
+            ImageAttachmentPreviewLayout.galleryFrame(
+                index: $0,
+                imageCount: 3,
+                tileSize: tile
+            )
+        }
+
+        XCTAssertEqual(frames[0], CGRect(x: 0, y: 0, width: 150, height: 308))
+        XCTAssertEqual(frames[1], CGRect(x: 158, y: 0, width: 150, height: 150))
+        XCTAssertEqual(frames[2], CGRect(x: 158, y: 158, width: 150, height: 150))
+    }
+
+    func testEvenImageGalleryKeepsTwoColumnGrid() {
+        let tile = CGSize(width: 150, height: 150)
+        XCTAssertEqual(
+            ImageAttachmentPreviewLayout.galleryFrame(
+                index: 3,
+                imageCount: 4,
+                tileSize: tile
+            ),
+            CGRect(x: 158, y: 158, width: 150, height: 150)
+        )
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {


### PR DESCRIPTION
## Summary

- size single-image previews from attachment metadata instead of a fixed 4:3 canvas
- render multi-image messages as clipped, edge-to-edge mosaics
- use a large leading tile with two stacked tiles for three-image messages
- keep queued uploads and the secondary SwiftUI renderer consistent
- add geometry coverage for portrait, landscape, extreme, fallback, and gallery layouts

## Why

Inline portrait images were rendered inside a hard-coded 220 × 165 point view using aspect-fit. The unused area appeared as dark side or top/bottom bands, making image messages feel clunky.

Single images now preserve their full intrinsic ratio within 280 × 320 point caps. Galleries intentionally crop into edge-to-edge tiles.

## Impact

Images display like modern chat clients without accidental letterboxing. Fullscreen viewing, downloads, authenticated loading, upload overlays, and message actions are unchanged.

## Validation

- `xcodebuild -workspace Revolt.xcworkspace -scheme Revolt -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.6' SWIFT_VERSION=5 build`
- `swiftc -parse RevoltTests/RevoltTests.swift`
- cross-account production QA: `ios_everyone_sender` sent and `ios_everyone_recipient` rendered the messages in Archem `testing`
- single-image cases: portrait JPEG 600 × 1000, landscape PNG 1000 × 600, square PNG 800 × 800
- gallery cases: 2, 3, and 4 images with mixed portrait, landscape, square, and 450 × 1400 ratios
- high-contrast edge fixtures confirmed no accidental letterboxing
- Hallmark screenshot audit confirmed intrinsic single-image sizing and filled mosaics; its initial incomplete three-image-grid finding was corrected and recaptured
- confirmed surrounding cell layout remains stable while scrolling

Before/after and cross-account QA screenshots were shared in #zeko-ios for verification.

Stacked on #48 (`agent/ios-everyone-mentions`).