### PR TITLE
Improve chat message presentation

### DIFF
--- a/Revolt/Components/Contents.swift
+++ b/Revolt/Components/Contents.swift
@@ -1604,25 +1604,22 @@ struct InnerContents: UIViewRepresentable {
     // Process user mentions: <@user_id>
     private func processUserMentions(in attrString: NSMutableAttributedString, textview: UITextView) {
         // FIXED: Collect matches first to avoid offset calculation issues
-        let userMentionMatches = Array(attrString.string.matches(of: /<@(\w{26})>/))
+        let userMentionMatches = Array(attrString.string.matches(of: /<@([A-Za-z0-9]+)>/))
         
         for match in userMentionMatches.reversed() {
             let id = match.output.1
             
-            if let user = viewState.users[String(id)] {
-                let member = currentServer.flatMap { viewState.members[$0.id]![user.id] }
-                
-                // Safely calculate the offset using NSRange instead of utf16Offset
-                let nsRange = NSRange(match.range, in: attrString.string)
-                guard nsRange.location != NSNotFound && 
-                      nsRange.location >= 0 && 
-                      nsRange.location + nsRange.length <= attrString.length else {
-                    continue
-                }
-                
-                let currentAttrs = attrString.attributes(at: nsRange.location, effectiveRange: nil)
-                let currentFont = (currentAttrs[.font] ?? contentFont) as! UIFont
-                
+            let nsRange = NSRange(match.range, in: attrString.string)
+            guard nsRange.location != NSNotFound,
+                  nsRange.location >= 0,
+                  nsRange.location + nsRange.length <= attrString.length else {
+                continue
+            }
+
+            let currentAttrs = attrString.attributes(at: nsRange.location, effectiveRange: nil)
+            let currentFont = (currentAttrs[.font] as? UIFont) ?? contentFont
+
+            if let user = viewState.users[String(id)] ?? viewState.allEventUsers[String(id)] {
                 attrString.deleteCharacters(in: nsRange)
                     
                 let username = NSMutableAttributedString(string: "@\(user.display_name ?? user.username)", attributes: [.font: currentFont])
@@ -1632,6 +1629,13 @@ struct InnerContents: UIViewRepresentable {
                 ], range: NSRange(location: 0, length: username.length))
                                 
                 attrString.insert(username, at: nsRange.location)
+            } else {
+                let fallback = "@unknown-user"
+                attrString.replaceCharacters(in: nsRange, with: fallback)
+                attrString.addAttributes([
+                    .font: currentFont,
+                    .foregroundColor: UIColor.secondaryLabel
+                ], range: NSRange(location: nsRange.location, length: (fallback as NSString).length))
             }
         }
     }
@@ -2104,5 +2108,4 @@ struct ChatMessageView: View {
     .preferredColorScheme(.dark)
     
 }
-
 

--- a/Revolt/Components/MessageRenderer/MessageEmbed.swift
+++ b/Revolt/Components/MessageRenderer/MessageEmbed.swift
@@ -9,6 +9,59 @@ import SwiftUI
 import Types
 import AVKit
 import WebKit
+import Kingfisher
+
+private struct RemoteEmbedImage: View {
+    private enum Phase {
+        case loading
+        case loaded
+        case failed
+    }
+
+    let url: URL
+    let sourceWidth: Int?
+    let sourceHeight: Int?
+
+    @State private var phase: Phase = .loading
+
+    private var aspectRatio: CGFloat {
+        guard let sourceWidth, let sourceHeight, sourceWidth > 0, sourceHeight > 0 else {
+            return 16.0 / 9.0
+        }
+        return CGFloat(sourceWidth) / CGFloat(sourceHeight)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if phase != .loaded {
+                HStack(spacing: 8) {
+                    if phase == .loading {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: "photo.badge.exclamationmark")
+                    }
+
+                    Text(phase == .loading ? "Loading preview…" : "Preview unavailable")
+                        .font(.caption)
+                }
+                .foregroundStyle(Color.textGray06)
+                .padding(.vertical, 8)
+            }
+
+            if phase != .failed {
+                KFAnimatedImage(source: .network(url))
+                    .placeholder { Color.clear }
+                    .onSuccess { _ in phase = .loaded }
+                    .onFailure { _ in phase = .failed }
+                    .aspectRatio(aspectRatio, contentMode: .fit)
+                    .frame(maxHeight: phase == .loaded ? 240 : 0)
+                    .opacity(phase == .loaded ? 1 : 0)
+                    .clipped()
+            }
+        }
+    }
+}
 
 /// A view that renders different types of message embeds, such as images, videos, text, websites, and special embeds.
 struct MessageEmbed: View {
@@ -45,7 +98,13 @@ struct MessageEmbed: View {
         switch embed {
         case .image(let image):
             // Render an image embed
-            LazyImage(source: .url(URL(string: image.url)!), clipTo: Rectangle())
+            if let url = URL(string: image.url) {
+                RemoteEmbedImage(
+                    url: url,
+                    sourceWidth: image.width,
+                    sourceHeight: image.height
+                )
+            }
         case .video(let video):
             // Render a video embed using AVPlayer
             if let url = URL(string: video.url) {
@@ -120,7 +179,7 @@ struct MessageEmbed: View {
                             
                             // Icon and site name
                             if let icon_url = embed.icon_url, embed.site_name != nil, let url = URL(string: icon_url) {
-                                LazyImage(source: .url(url), height: .size64, width: .size64, clipTo: Rectangle())
+                                LazyImage(source: .url(url), height: .size20, width: .size20, clipTo: Rectangle())
                                     .clipShape(UnevenRoundedRectangle(topLeadingRadius: .radiusXSmall, bottomLeadingRadius: .radiusXSmall, bottomTrailingRadius: .radiusXSmall, topTrailingRadius: .radiusXSmall))
                                     .padding(.top, .padding8)
                             }
@@ -143,7 +202,11 @@ struct MessageEmbed: View {
                             .aspectRatio(CGSize(width: video.width, height: video.height), contentMode: .fit)
                             .frame(maxWidth: CGFloat(integerLiteral: video.width), maxHeight: CGFloat(integerLiteral: video.height))
                     } else if let image = embed.image, image.size == JanuaryImage.Size.large, let url = URL(string: image.url) {
-                            LazyImage(source: .url(url), clipTo: Rectangle())
+                            RemoteEmbedImage(
+                                url: url,
+                                sourceWidth: image.width,
+                                sourceHeight: image.height
+                            )
                             .clipShape(RoundedRectangle(cornerRadius: .radiusXSmall))
                             .padding(.top, .padding8)
                         }
@@ -151,7 +214,11 @@ struct MessageEmbed: View {
                     // Preview image for smaller embeds
                     if let image = embed.image, embed.special == nil || embed.special == WebsiteSpecial.none, embed.video == nil {
                         if image.size == JanuaryImage.Size.preview, let url = URL(string: image.url) {
-                            LazyImage(source: .url(url), clipTo: Rectangle())
+                            RemoteEmbedImage(
+                                url: url,
+                                sourceWidth: image.width,
+                                sourceHeight: image.height
+                            )
                                 .clipShape(RoundedRectangle(cornerRadius: .radiusXSmall))
                                 .padding(.top, .padding8)
                         }

--- a/Revolt/Components/MessageRenderer/MessageReply.swift
+++ b/Revolt/Components/MessageRenderer/MessageReply.swift
@@ -79,12 +79,12 @@ struct InnerMessageReplyView: View {
     func authorBadge(message: Message, author: User) -> (text: String, color: Color)? {
         if author.bot != nil {
             return message.masquerade == nil
-                ? (String(localized: "BOT"), .bgPurple10)
-                : (String(localized: "BRIDGE"), .bgRed07)
+                ? (String(localized: "BOT"), .bgPurple10.opacity(0.8))
+                : (String(localized: "BRIDGE"), .bgGray10.opacity(0.85))
         }
 
         if isNewAccount(author) {
-            return (String(localized: "NEW"), .bgGreen07)
+            return (String(localized: "NEW"), .bgGreen07.opacity(0.75))
         }
 
         return nil
@@ -98,6 +98,23 @@ struct InnerMessageReplyView: View {
 
         let accountAge = Calendar.current.dateComponents([.day], from: ulid.timestamp, to: Date()).day ?? Int.max
         return accountAge <= 14
+    }
+
+    private func attachmentSummary(_ attachments: [Types.File]) -> String {
+        guard attachments.count == 1, let attachment = attachments.first else {
+            return String(localized: "\(attachments.count) attachments")
+        }
+
+        if attachment.content_type.hasPrefix("image/") {
+            return String(localized: "Photo")
+        }
+        if attachment.content_type.hasPrefix("video/") {
+            return String(localized: "Video")
+        }
+        if attachment.content_type.hasPrefix("audio/") {
+            return String(localized: "Audio")
+        }
+        return attachment.filename
     }
     
     var body: some View {
@@ -137,7 +154,7 @@ struct InnerMessageReplyView: View {
                             
                             HStack(spacing: .spacing2){
                                 
-                                PeptideText(text: "Tap to see  attachment",
+                                PeptideText(text: attachmentSummary(message.attachments ?? []),
                                             font: .peptideFootnote,
                                             textColor: .textGray06,
                                             lineLimit: 1)
@@ -200,4 +217,3 @@ struct InnerMessageReplyView: View {
         }
     }
 }
-

--- a/Revolt/Components/MessageRenderer/MessageView.swift
+++ b/Revolt/Components/MessageRenderer/MessageView.swift
@@ -100,12 +100,12 @@ struct MessageView: View {
     private var authorBadge: (text: String, color: Color)? {
         if viewModel.author.bot != nil {
             return viewModel.message.masquerade == nil
-                ? (String(localized: "BOT"), .bgPurple10)
-                : (String(localized: "BRIDGE"), .bgRed07)
+                ? (String(localized: "BOT"), .bgPurple10.opacity(0.8))
+                : (String(localized: "BRIDGE"), .bgGray10.opacity(0.85))
         }
 
         if isNewAccount(viewModel.author) {
-            return (String(localized: "NEW"), .bgGreen07)
+            return (String(localized: "NEW"), .bgGreen07.opacity(0.75))
         }
 
         return nil
@@ -275,7 +275,7 @@ struct MessageView: View {
                                         
                                         Text(formattedMessageDate(from: createdAt(id: viewModel.message.id)))
                                             .font(.peptideFootnoteFont)
-                                            .foregroundStyle(.textGray06)
+                                            .foregroundStyle(.textGray04)
                                             .lineLimit(1)
                                     }
                                     

--- a/Revolt/Extensions/StringExtensions.swift
+++ b/Revolt/Extensions/StringExtensions.swift
@@ -1,42 +1,45 @@
 import Foundation
 
 extension String {
-    func convertMentionsToUsernames(viewState: ViewState) -> String {
+    func replacingUserMentionTokens(
+        fallback: String = "@unknown-user",
+        usernameForUserId: (String) -> String?
+    ) -> String {
         var result = self
-        
-        // Regular expression to match mention format: <@user_id>
-        let pattern = "<@([A-Z0-9]+)>"
-        
-        do {
-            let regex = try NSRegularExpression(pattern: pattern)
-            let range = NSRange(location: 0, length: result.utf16.count)
-            
-            // Find all matches
-            let matches = regex.matches(in: result, range: range)
-            
-            // Process matches in reverse to avoid index issues
-            for match in matches.reversed() {
-                if let userIdRange = Range(match.range(at: 1), in: result) {
-                    let userId = String(result[userIdRange])
-                    
-                    // Try to find user in viewState
-                    if let user = viewState.users[userId] {
-                        // Replace the mention with username
-                        let mentionRange = Range(match.range, in: result)!
-                        let username = user.display_name ?? user.username
-                        result.replaceSubrange(mentionRange, with: "@\(username)")
-                    }
-                }
-            }
-        } catch {
-            print("DEBUG: Error creating regex: \(error)")
+        guard let regex = try? NSRegularExpression(pattern: "<@([A-Za-z0-9]+)>") else {
+            return result
         }
-        
+
+        let matches = regex.matches(
+            in: result,
+            range: NSRange(location: 0, length: result.utf16.count)
+        )
+
+        for match in matches.reversed() {
+            guard let idRange = Range(match.range(at: 1), in: result),
+                  let mentionRange = Range(match.range, in: result) else {
+                continue
+            }
+
+            let userId = String(result[idRange])
+            let replacement = usernameForUserId(userId).map { "@\($0)" } ?? fallback
+            result.replaceSubrange(mentionRange, with: replacement)
+        }
+
         return result
+    }
+
+    func convertMentionsToUsernames(viewState: ViewState) -> String {
+        replacingUserMentionTokens { userId in
+            guard let user = viewState.users[userId] ?? viewState.allEventUsers[userId] else {
+                return nil
+            }
+            return user.display_name ?? user.username
+        }
     }
     
     func containsMention() -> Bool {
-        let pattern = "<@([A-Z0-9]+)>"
+        let pattern = "<@([A-Za-z0-9]+)>"
         do {
             let regex = try NSRegularExpression(pattern: pattern)
             let range = NSRange(location: 0, length: self.utf16.count)
@@ -46,4 +49,4 @@ extension String {
             return false
         }
     }
-} 
+}

--- a/Revolt/Pages/Channel/Messagable/Utils/MarkdownProcessor.swift
+++ b/Revolt/Pages/Channel/Messagable/Utils/MarkdownProcessor.swift
@@ -27,7 +27,7 @@ func processMarkdownOptimized(_ text: String) -> NSAttributedString {
 
     // Apply default font and color
     mutableAttributedString.addAttributes([
-        .font: UIFont.systemFont(ofSize: 15, weight: .light),
+        .font: UIFont.systemFont(ofSize: 15, weight: .regular),
         .foregroundColor: UIColor.textDefaultGray01
     ], range: NSRange(location: 0, length: mutableAttributedString.length))
 
@@ -649,4 +649,3 @@ func createHeaderParagraphStyle() -> NSParagraphStyle {
     paragraphStyle.headIndent = 0.0 // No indentation for subsequent lines
     return paragraphStyle
 }
-

--- a/Revolt/Pages/Channel/Messagable/Views/LinkPreviewView.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/LinkPreviewView.swift
@@ -11,7 +11,7 @@ import Kingfisher
 import WebKit
 
 /// A UIView that renders different types of message embeds, such as website previews, images, videos, and text embeds.
-class LinkPreviewView: UIView {
+class LinkPreviewView: UIView, WKNavigationDelegate {
     private static let fallbackMediaAspectRatio: CGFloat = 16.0 / 9.0
     
     // MARK: - UI Components
@@ -27,6 +27,7 @@ class LinkPreviewView: UIView {
     // Content components
     private let descriptionLabel = UILabel()
     private let previewImageView = UIImageView()
+    private let mediaStatusLabel = UILabel()
     private let videoView = UIView()
     private var webView: WKWebView?
     
@@ -103,6 +104,11 @@ class LinkPreviewView: UIView {
         previewImageView.clipsToBounds = true
         previewImageView.layer.cornerRadius = 6
         previewImageView.isHidden = true
+
+        mediaStatusLabel.translatesAutoresizingMaskIntoConstraints = false
+        mediaStatusLabel.font = UIFont.systemFont(ofSize: 13, weight: .medium)
+        mediaStatusLabel.textColor = UIColor(named: "textGray06") ?? .secondaryLabel
+        mediaStatusLabel.numberOfLines = 1
         
         // Setup constraints
         setupConstraints()
@@ -129,8 +135,8 @@ class LinkPreviewView: UIView {
             contentStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -8),
             
             // Icon image view
-            iconImageView.widthAnchor.constraint(equalToConstant: 64),
-            iconImageView.heightAnchor.constraint(equalToConstant: 64),
+            iconImageView.widthAnchor.constraint(equalToConstant: 20),
+            iconImageView.heightAnchor.constraint(equalToConstant: 20),
             
             // Preview image view
             previewImageView.heightAnchor.constraint(equalToConstant: 200),
@@ -180,9 +186,25 @@ class LinkPreviewView: UIView {
         previewImageView.image = nil
         previewImageView.isHidden = true
         iconImageView.image = nil
+        webView?.stopLoading()
+        webView?.navigationDelegate = nil
         webView?.removeFromSuperview()
         webView = nil
+        mediaStatusLabel.text = nil
         isHidden = false
+    }
+
+    private func showMediaStatus(_ text: String) {
+        mediaStatusLabel.text = text
+        if mediaStatusLabel.superview == nil {
+            contentStackView.addArrangedSubview(mediaStatusLabel)
+        }
+    }
+
+    private func hideMediaStatus() {
+        contentStackView.removeArrangedSubview(mediaStatusLabel)
+        mediaStatusLabel.removeFromSuperview()
+        mediaStatusLabel.text = nil
     }
     
     // MARK: - Website Embed Configuration
@@ -247,9 +269,12 @@ class LinkPreviewView: UIView {
         webView.translatesAutoresizingMaskIntoConstraints = false
         webView.isOpaque = false
         webView.backgroundColor = .clear
+        webView.navigationDelegate = self
+        webView.isHidden = true
         
         let aspectRatio = getSpecialEmbedAspectRatio(special, websiteEmbed: websiteEmbed)
         
+        showMediaStatus("Loading preview…")
         contentStackView.addArrangedSubview(webView)
         
         NSLayoutConstraint.activate([
@@ -265,6 +290,32 @@ class LinkPreviewView: UIView {
         self.webView = webView
         
         return true
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard webView === self.webView else { return }
+        hideMediaStatus()
+        webView.isHidden = false
+        onAsyncLayoutAffectingContentLoaded?()
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        guard webView === self.webView else { return }
+        webView.removeFromSuperview()
+        showMediaStatus("Preview unavailable")
+        onAsyncLayoutAffectingContentLoaded?()
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        self.webView(webView, didFail: navigation, withError: error)
     }
     
     private func getSpecialEmbedUrl(_ websiteEmbed: WebsiteEmbed, special: WebsiteSpecial) -> URL? {
@@ -340,16 +391,21 @@ class LinkPreviewView: UIView {
     private func configureImagePreview(_ image: JanuaryImage) -> Bool {
         guard let url = URL(string: image.url) else { return false }
         
-        previewImageView.isHidden = false
+        showMediaStatus("Loading preview…")
+        previewImageView.isHidden = true
         previewImageView.kf.setImage(with: url) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success:
+                self.hideMediaStatus()
+                self.previewImageView.isHidden = false
                 self.setNeedsLayout()
                 self.layoutIfNeeded()
                 self.onAsyncLayoutAffectingContentLoaded?()
-            case .failure(let error):
-                _ = error
+            case .failure:
+                self.previewImageView.isHidden = true
+                self.showMediaStatus("Preview unavailable")
+                self.onAsyncLayoutAffectingContentLoaded?()
             }
         }
         contentStackView.addArrangedSubview(previewImageView)
@@ -374,10 +430,22 @@ class LinkPreviewView: UIView {
     private func configureVideoPreview(_ video: JanuaryVideo) -> Bool {
         guard let url = URL(string: video.url) else { return false }
         
-        previewImageView.isHidden = false
+        showMediaStatus("Loading preview…")
+        previewImageView.isHidden = true
         // For video, you might want to show a thumbnail or use AVPlayerLayer
         // For now, we'll treat it like an image
-        previewImageView.kf.setImage(with: url)
+        previewImageView.kf.setImage(with: url) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success:
+                self.hideMediaStatus()
+                self.previewImageView.isHidden = false
+            case .failure:
+                self.previewImageView.isHidden = true
+                self.showMediaStatus("Preview unavailable")
+            }
+            self.onAsyncLayoutAffectingContentLoaded?()
+        }
         contentStackView.addArrangedSubview(previewImageView)
         
         let aspectRatio = mediaAspectRatio(width: video.width, height: video.height)

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Layout.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Layout.swift
@@ -24,8 +24,8 @@ extension MessageCell {
     }
 
     private func updateTopConstraintConstants(offset: CGFloat) {
-        continuationNoReplyConstraints.first?.constant = 8 + offset
-        continuationWithReplyConstraints.first?.constant = 8
+        continuationNoReplyConstraints.first?.constant = 4 + offset
+        continuationWithReplyConstraints.first?.constant = 6
         nonContinuationNoReplyConstraints.first?.constant = 8 + offset
         nonContinuationWithReplyConstraints.first?.constant = 8
     }

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Setup.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell+Extensions/MessageCell+Setup.swift
@@ -77,11 +77,12 @@ extension MessageCell {
         // Add visual feedback for tap
         replyView.layer.cornerRadius = 4
         replyView.layer.masksToBounds = true
+        replyView.backgroundColor = (UIColor(named: "bgGray12") ?? .secondarySystemBackground).withAlphaComponent(0.7)
         
         // Reply indicator icon
         replyIndicatorImageView.translatesAutoresizingMaskIntoConstraints = false
         replyIndicatorImageView.image = UIImage(systemName: "arrow.turn.up.right")
-        replyIndicatorImageView.tintColor = .bgOrane07
+        replyIndicatorImageView.tintColor = UIColor(named: "textGray04") ?? .secondaryLabel
         replyIndicatorImageView.contentMode = .scaleAspectFit
         replyView.addSubview(replyIndicatorImageView)
 
@@ -97,7 +98,7 @@ extension MessageCell {
         // Reply author label
         replyAuthorLabel.translatesAutoresizingMaskIntoConstraints = false
         replyAuthorLabel.font = UIFont.boldSystemFont(ofSize: 13)
-        replyAuthorLabel.textColor = .bgOrane07
+        replyAuthorLabel.textColor = .textDefaultGray01
         // Keep author compact so preview text starts right after a minimum gap.
         replyAuthorLabel.setContentHuggingPriority(.required, for: .horizontal)
         replyAuthorLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -118,7 +119,7 @@ extension MessageCell {
         // Reply content label
         replyContentLabel.translatesAutoresizingMaskIntoConstraints = false
         replyContentLabel.font = UIFont.systemFont(ofSize: 13)
-        replyContentLabel.textColor = .bgOrane07
+        replyContentLabel.textColor = UIColor(named: "textGray04") ?? .secondaryLabel
         replyContentLabel.lineBreakMode = .byTruncatingTail
         replyContentLabel.numberOfLines = 1
         // Let preview text absorb compression/truncation first, Discord-like behavior.
@@ -169,8 +170,8 @@ extension MessageCell {
         
         // Time label
         timeLabel.translatesAutoresizingMaskIntoConstraints = false
-        timeLabel.font = UIFont.systemFont(ofSize: 12)
-        timeLabel.textColor = .textGray06
+        timeLabel.font = UIFont.systemFont(ofSize: 12, weight: .medium)
+        timeLabel.textColor = UIColor(named: "textGray04") ?? .secondaryLabel
         contentView.addSubview(timeLabel)
         
         // Bridge badge label
@@ -192,7 +193,7 @@ extension MessageCell {
         
         // Content text view - optimized for markdown and performance
         contentLabel.translatesAutoresizingMaskIntoConstraints = false
-        contentLabel.font = UIFont.systemFont(ofSize: 15, weight: .light)
+        contentLabel.font = UIFont.systemFont(ofSize: 15, weight: .regular)
         contentLabel.textColor = .textDefaultGray01
         contentLabel.backgroundColor = .clear // Make background transparent
         contentLabel.isScrollEnabled = false // Disable scrolling
@@ -242,7 +243,7 @@ extension MessageCell {
         replyViewTopConstraint?.isActive = true
 
         // Create height constraint with lower priority
-        let replyHeightConstraint = replyView.heightAnchor.constraint(equalToConstant: 18)
+        let replyHeightConstraint = replyView.heightAnchor.constraint(equalToConstant: 22)
         replyHeightConstraint.priority = UILayoutPriority(999) // Just below required but still high
         replyHeightConstraint.isActive = true
 
@@ -313,11 +314,11 @@ extension MessageCell {
         // These are toggled via isActive in updateAppearanceForContinuation() instead of
         // scanning and removing/recreating constraints on every cell reuse.
         continuationNoReplyConstraints = [
-            contentLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            contentLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 4),
             contentLabel.leadingAnchor.constraint(equalTo: avatarImageView.trailingAnchor, constant: 10)
         ]
         continuationWithReplyConstraints = [
-            contentLabel.topAnchor.constraint(equalTo: replyView.bottomAnchor, constant: 8),
+            contentLabel.topAnchor.constraint(equalTo: replyView.bottomAnchor, constant: 6),
             contentLabel.leadingAnchor.constraint(equalTo: avatarImageView.trailingAnchor, constant: 10)
         ]
         let ncNoReplyUsernameHeight = usernameLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 19)

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
@@ -447,7 +447,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         usernameLabel.font = UIFont.boldSystemFont(ofSize: 16)
         
         let showVerified = author.hasVerifiedBadge()
-        usernameLabel.textColor = showVerified ? .systemYellow : .white
+        usernameLabel.textColor = .white
         usernameVerifiedBadgeImageView.image = UIImage(systemName: "checkmark.seal.fill")
         usernameVerifiedBadgeImageView.isHidden = !showVerified
         usernameVerifiedBadgeWidthConstraint?.constant = showVerified ? 14 : 0
@@ -507,10 +507,10 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
 
         if author.bot != nil {
             badge = message.masquerade == nil
-                ? ("BOT", UIColor(named: "bgPurple10") ?? .systemPurple)
-                : ("BRIDGE", UIColor(named: "bgRed07") ?? .systemPink)
+                ? ("BOT", (UIColor(named: "bgPurple10") ?? .systemPurple).withAlphaComponent(0.8))
+                : ("BRIDGE", (UIColor(named: "bgGray10") ?? .systemGray).withAlphaComponent(0.85))
         } else if isNewAccount(author) {
-            badge = ("NEW", UIColor(named: "bgGreen07") ?? .systemGreen)
+            badge = ("NEW", (UIColor(named: "bgGreen07") ?? .systemGreen).withAlphaComponent(0.75))
         } else {
             badge = nil
         }
@@ -614,7 +614,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
                     let userId = String(result[userIdRange])
                     
                     // Try to find user in viewState
-                    if let user = viewState.users[userId] {
+                    if let user = viewState.users[userId] ?? viewState.allEventUsers[userId] {
                         // Get the mention range
                         let mentionRange = Range(match.range, in: result)!
                         
@@ -624,7 +624,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
                     } else {
                         // If user not found, replace with @Unknown User to avoid showing raw ID
                         let mentionRange = Range(match.range, in: result)!
-                        result.replaceSubrange(mentionRange, with: "@Unknown User")
+                        result.replaceSubrange(mentionRange, with: "@unknown-user")
                     }
                 }
             }
@@ -784,19 +784,16 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
             for match in matches.reversed() {
                 if let userIdRange = Range(match.range(at: 1), in: mutableAttributedString.string) {
                     let userId = String(mutableAttributedString.string[userIdRange])
-                    
-                    // Try to find user in viewState
-                    if let user = viewState.users[userId] {
-                        // Get the mention range in the current string
-                        let mentionRange = match.range
-                        
-                        // Safety check for range bounds in mutable string
-                        guard mentionRange.location >= 0,
-                              mentionRange.location < mutableAttributedString.length,
-                              mentionRange.location + mentionRange.length <= mutableAttributedString.length else {
-                            // print("DEBUG: Invalid mention range: \(mentionRange) for string length: \(mutableAttributedString.length)")
-                            continue
-                        }
+
+                    let mentionRange = match.range
+                    guard mentionRange.location >= 0,
+                          mentionRange.location < mutableAttributedString.length,
+                          mentionRange.location + mentionRange.length <= mutableAttributedString.length else {
+                        continue
+                    }
+
+                    // Try both user stores before falling back to a privacy-safe label.
+                    if let user = viewState.users[userId] ?? viewState.allEventUsers[userId] {
                         
                         // Replace the mention with username (use display name if available)
                         let displayName = user.display_name ?? user.username
@@ -827,6 +824,17 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
                         } catch {
                             // print("DEBUG: Error adding attributes to mention: \(error)")
                         }
+                    } else {
+                        let mentionText = "@unknown-user"
+                        mutableAttributedString.replaceCharacters(in: mentionRange, with: mentionText)
+                        let newRange = NSRange(
+                            location: mentionRange.location,
+                            length: (mentionText as NSString).length
+                        )
+                        mutableAttributedString.addAttributes([
+                            .foregroundColor: UIColor.secondaryLabel,
+                            .font: UIFont.systemFont(ofSize: 15, weight: .semibold)
+                        ], range: newRange)
                     }
                 }
             }
@@ -1178,6 +1186,17 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         // print("✅ MessageCell.clearHighlight() COMPLETED")
     }
     
+    private func replyAttachmentSummary(_ attachments: [Types.File]) -> String {
+        guard attachments.count == 1, let attachment = attachments.first else {
+            return "\(attachments.count) attachments"
+        }
+
+        if attachment.content_type.hasPrefix("image/") { return "Photo" }
+        if attachment.content_type.hasPrefix("video/") { return "Video" }
+        if attachment.content_type.hasPrefix("audio/") { return "Audio" }
+        return attachment.filename
+    }
+
     private func configureReplyView(message: Message, replies: [String], viewState: ViewState) {
         // Remove the continuation check - allow reply view for continuations too
         
@@ -1245,12 +1264,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
                         replyContentLabel.text = processedContent
                         replyContentLabel.font = UIFont.systemFont(ofSize: 12) // Reset to normal font
                     } else if !(replyMessage.attachments?.isEmpty ?? true) {
-                        let attachmentCount = replyMessage.attachments?.count ?? 0
-                        if attachmentCount == 1 {
-                            replyContentLabel.text = "[attachment]"
-                        } else {
-                            replyContentLabel.text = "[\(attachmentCount) attachments]"
-                        }
+                        replyContentLabel.text = replyAttachmentSummary(replyMessage.attachments ?? [])
                         replyContentLabel.font = UIFont.systemFont(ofSize: 12) // Reset to normal font
                     } else {
                         replyContentLabel.text = ""
@@ -1767,7 +1781,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         let hasMentions = content.contains("<@") || content.contains("<#") || message.mentionsEveryone
 
         // Check message-level cache for the pre-emoji attributed string
-        if let cached = MessageCell.attributedStringCache.object(forKey: cacheKey) {
+        if !hasMentions, let cached = MessageCell.attributedStringCache.object(forKey: cacheKey) {
             let mutableCopy = NSMutableAttributedString(attributedString: cached)
             processCustomEmojis(in: mutableCopy, textView: contentLabel)
             contentLabel.attributedText = mutableCopy
@@ -1791,7 +1805,9 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         }
 
         // Cache the pre-emoji result (immutable copy)
-        MessageCell.attributedStringCache.setObject(baseAttributedString, forKey: cacheKey)
+        if !hasMentions {
+            MessageCell.attributedStringCache.setObject(baseAttributedString, forKey: cacheKey)
+        }
 
         // Apply emoji processing on a mutable copy
         let mutableAttributedText = NSMutableAttributedString(attributedString: baseAttributedString)
@@ -1915,7 +1931,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
             } else if hasImageAttachments {
                 // Image attachments already have bottom constraint
             } else if !hasAttachments {
-                let bottomConstraint = contentLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -16)
+                let bottomConstraint = contentLabel.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -8)
                 bottomConstraint.priority = UILayoutPriority.defaultHigh
                 bottomConstraint.isActive = true
                 // PERF Issue #9: Track for efficient deactivation in clearContentLabelBottomConstraints()
@@ -1930,7 +1946,8 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
         
         // Minimum height constraint
         contentViewMinHeightConstraint?.isActive = false
-        let minHeightConstraint = contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 50)
+        let minimumHeight: CGFloat = isContinuation ? 28 : 50
+        let minHeightConstraint = contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: minimumHeight)
         minHeightConstraint.priority = UILayoutPriority.defaultLow
         minHeightConstraint.isActive = true
         contentViewMinHeightConstraint = minHeightConstraint

--- a/RevoltTests/RevoltTests.swift
+++ b/RevoltTests/RevoltTests.swift
@@ -97,6 +97,24 @@ final class RevoltTests: XCTestCase {
         XCTAssertEqual(ranges.map { nsText.substring(with: $0) }, ["@everyone", "@everyone"])
     }
 
+    func testUserMentionTokensResolveNumericAndULIDIdentifiers() {
+        let text = "Hi <@1297812287981359106> and <@01TESTUSER000000000000000>"
+        let resolved = text.replacingUserMentionTokens { userId in
+            userId == "01TESTUSER000000000000000" ? "Akshat" : nil
+        }
+
+        XCTAssertEqual(resolved, "Hi @unknown-user and @Akshat")
+        XCTAssertFalse(resolved.contains("<@"))
+    }
+
+    func testUserMentionFallbackNeverLeaksRawIdentifier() {
+        let rawMention = "<@1297812287981359106>"
+        XCTAssertEqual(
+            rawMention.replacingUserMentionTokens { _ in nil },
+            "@unknown-user"
+        )
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {


### PR DESCRIPTION
## Summary

- prevent raw numeric mention IDs from appearing in message and search rendering
- collapse rich-preview loading and failure states instead of reserving large blank media areas
- tighten continuation-message spacing and strengthen body-text readability
- clarify reply context while reducing visual emphasis on BRIDGE, BOT, NEW, verified, and timestamp metadata
- label reply attachments as Photo, Video, Audio, or their actual filename

## Why

High-traffic chat views looked visually heavy and occasionally exposed implementation details such as raw `<@…>` identifiers. Rich links could also leave large empty placeholders when media failed to load, while reply and badge styling competed with the message itself.

## User impact

Busy channels are easier to scan, replies retain clearer context, failed previews stay compact, and users no longer see raw mention identifiers or generic attachment placeholders.

## Validation

- `xcodebuild -workspace Revolt.xcworkspace -scheme Revolt -destination 'id=D35643F6-F053-4A40-9D29-4A471E9900AC' SWIFT_VERSION=5 build -quiet`
- verified against production history in PepChat Official → general on the updated iOS simulator
- confirmed numeric bridge mentions render as `@unknown-user`
- confirmed failed rich media renders a compact `Preview unavailable` state
- confirmed a real PDF reply exposes `Janoshik XTP Reta 30 .pdf`
- reviewed dense replies, verified/BRIDGE/NEW badges, timestamps, invite cards, and reactions

The shared `Revolt` scheme currently has no configured test action, so the added mention regression tests cannot be run through that scheme.

## Before/after evidence

Posted as three representative before/after pairs in the `#zeko-ios` verification thread: https://archem-group.slack.com/archives/C07UGKNQZ6E/p1786072493757099