### PR TITLE
Add swiping to the full-screen image viewer

### DIFF
--- a/Revolt/Pages/Channel/Messagable/Controllers/FullScreenImageViewController.swift
+++ b/Revolt/Pages/Channel/Messagable/Controllers/FullScreenImageViewController.swift
@@ -8,33 +8,81 @@ import UIKit
 import Photos
 import Kingfisher
 
+struct FullScreenImageItem {
+    let previewImage: UIImage?
+    let originalImageURL: URL?
+    let sessionToken: String?
+}
+
+enum FullScreenImageGalleryNavigation {
+    static func destinationIndex(currentIndex: Int, itemCount: Int, step: Int) -> Int? {
+        guard itemCount > 1, abs(step) == 1 else { return nil }
+        let destination = currentIndex + step
+        return (0..<itemCount).contains(destination) ? destination : nil
+    }
+
+    static func positionText(currentIndex: Int, itemCount: Int) -> String? {
+        guard itemCount > 1, (0..<itemCount).contains(currentIndex) else { return nil }
+        return "\(currentIndex + 1) of \(itemCount)"
+    }
+}
+
 // MARK: - FullScreenImageViewController
-class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
+class FullScreenImageViewController: UIViewController, UIScrollViewDelegate, UIGestureRecognizerDelegate {
     private let scrollView = UIScrollView()
     private let imageView = UIImageView()
     private let closeButton = UIButton(type: .system)
     private let downloadButton = UIButton(type: .system)
     private let buttonStackView = UIStackView()
+    private let positionLabel = UILabel()
+    private let items: [FullScreenImageItem]
+    private var currentIndex: Int
+    private var originalImageDataByIndex: [Int: Data] = [:]
+    private var originalImageDataTask: URLSessionDataTask?
+    private var isTransitioningBetweenImages = false
+    private lazy var swipeLeftGesture = UISwipeGestureRecognizer(
+        target: self,
+        action: #selector(handleGallerySwipe(_:))
+    )
+    private lazy var swipeRightGesture = UISwipeGestureRecognizer(
+        target: self,
+        action: #selector(handleGallerySwipe(_:))
+    )
     
     // Zoom properties
     private var minZoomScale: CGFloat = 1.0
     private var maxZoomScale: CGFloat = 5.0
     private var hasSetInitialZoom = false
-    private let originalImageURL: URL?
-    private let sessionToken: String?
-    private var originalImageData: Data?
-    
-    init(image: UIImage, originalImageURL: URL?, sessionToken: String?) {
-        self.originalImageURL = originalImageURL
-        self.sessionToken = sessionToken
+
+    init(items: [FullScreenImageItem], initialIndex: Int) {
+        precondition(!items.isEmpty, "Full-screen image gallery requires at least one item")
+        self.items = items
+        self.currentIndex = min(max(0, initialIndex), items.count - 1)
         super.init(nibName: nil, bundle: nil)
-        imageView.image = image
+        imageView.image = items[self.currentIndex].previewImage
         modalPresentationStyle = .fullScreen
         modalTransitionStyle = .crossDissolve
+    }
+
+    convenience init(image: UIImage, originalImageURL: URL?, sessionToken: String?) {
+        self.init(
+            items: [
+                FullScreenImageItem(
+                    previewImage: image,
+                    originalImageURL: originalImageURL,
+                    sessionToken: sessionToken
+                )
+            ],
+            initialIndex: 0
+        )
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        originalImageDataTask?.cancel()
     }
     
     override func viewDidLoad() {
@@ -45,11 +93,14 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
         setupImageView()
         setupButtons()
         setupGestures()
-        loadOriginalImageIfAvailable()
+        displayCurrentItem()
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        if !hasSetInitialZoom {
+            setInitialZoomScale()
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -66,6 +117,7 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
         scrollView.decelerationRate = UIScrollView.DecelerationRate.fast
         scrollView.bouncesZoom = true
         scrollView.bounces = true
+        scrollView.alwaysBounceHorizontal = true
         scrollView.contentInsetAdjustmentBehavior = .never
         
         view.addSubview(scrollView)
@@ -114,6 +166,16 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
         buttonStackView.addArrangedSubview(closeButton)
         
         view.addSubview(buttonStackView)
+
+        positionLabel.translatesAutoresizingMaskIntoConstraints = false
+        positionLabel.font = UIFont.systemFont(ofSize: 13, weight: .semibold)
+        positionLabel.textColor = .white
+        positionLabel.textAlignment = .center
+        positionLabel.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        positionLabel.layer.cornerRadius = 14
+        positionLabel.layer.masksToBounds = true
+        positionLabel.isAccessibilityElement = true
+        view.addSubview(positionLabel)
         
         NSLayoutConstraint.activate([
             // Button size constraints
@@ -124,7 +186,12 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
             
             // Stack view position
             buttonStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
-            buttonStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16)
+            buttonStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+
+            positionLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            positionLabel.centerYAnchor.constraint(equalTo: buttonStackView.centerYAnchor),
+            positionLabel.heightAnchor.constraint(equalToConstant: 28),
+            positionLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 54)
         ])
     }
     
@@ -141,17 +208,40 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
         
         // Make sure single tap doesn't interfere with double tap
         singleTapGesture.require(toFail: doubleTapGesture)
+
+        swipeLeftGesture.direction = .left
+        swipeRightGesture.direction = .right
+        swipeLeftGesture.delegate = self
+        swipeRightGesture.delegate = self
+        scrollView.addGestureRecognizer(swipeLeftGesture)
+        scrollView.addGestureRecognizer(swipeRightGesture)
+
+        // Give gallery swipes first chance at the fitted scale. When zoomed in,
+        // the swipe delegates decline and UIScrollView keeps normal image panning.
+        scrollView.panGestureRecognizer.require(toFail: swipeLeftGesture)
+        scrollView.panGestureRecognizer.require(toFail: swipeRightGesture)
+
     }
     
     private func setInitialZoomScale() {
         guard let image = imageView.image else { return }
-        hasSetInitialZoom = true
         
         let scrollViewSize = scrollView.bounds.size
         guard scrollViewSize.width > 0 && scrollViewSize.height > 0 else { return }
         
         let imageSize = image.size
         guard imageSize.width > 0 && imageSize.height > 0 else { return }
+
+        hasSetInitialZoom = true
+
+        // Clear the previous item's zoom transform before changing the image view's
+        // geometry. Without this reset, assigning a new frame while UIScrollView is
+        // still scaled can leave the next image thumbnail-sized or off screen.
+        scrollView.minimumZoomScale = 0.01
+        scrollView.maximumZoomScale = max(scrollView.maximumZoomScale, 1)
+        scrollView.setZoomScale(1, animated: false)
+        scrollView.contentInset = .zero
+        scrollView.contentOffset = .zero
         
         // Set imageView frame to match image size
         imageView.frame = CGRect(origin: .zero, size: imageSize)
@@ -191,11 +281,136 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
             right: horizontalInset
         )
     }
-    
+
+    private func displayCurrentItem() {
+        imageView.kf.cancelDownloadTask()
+        originalImageDataTask?.cancel()
+        originalImageDataTask = nil
+
+        hasSetInitialZoom = false
+        scrollView.minimumZoomScale = 0.01
+        scrollView.maximumZoomScale = max(scrollView.maximumZoomScale, 1)
+        scrollView.setZoomScale(1, animated: false)
+        scrollView.contentInset = .zero
+
+        let item = items[currentIndex]
+        imageView.image = item.previewImage ?? UIImage(systemName: "photo")
+        imageView.alpha = 1
+        imageView.accessibilityLabel = "Image \(currentIndex + 1) of \(items.count)"
+
+        positionLabel.text = FullScreenImageGalleryNavigation.positionText(
+            currentIndex: currentIndex,
+            itemCount: items.count
+        )
+        positionLabel.accessibilityLabel = positionLabel.text
+        positionLabel.isHidden = items.count <= 1
+
+        view.layoutIfNeeded()
+        setInitialZoomScale()
+        loadOriginalImageIfAvailable()
+    }
+
+    @objc private func handleGallerySwipe(_ gesture: UISwipeGestureRecognizer) {
+        let step = gesture.direction == .left ? 1 : -1
+        guard let destination = FullScreenImageGalleryNavigation.destinationIndex(
+            currentIndex: currentIndex,
+            itemCount: items.count,
+            step: step
+        ) else {
+            return
+        }
+
+        transitionToImage(at: destination, step: step)
+    }
+
+    private func transitionToImage(at requestedIndex: Int, step: Int) {
+        guard !isTransitioningBetweenImages else { return }
+        guard let destination = FullScreenImageGalleryNavigation.destinationIndex(
+            currentIndex: currentIndex,
+            itemCount: items.count,
+            step: step
+        ), destination == requestedIndex else {
+            restoreGalleryPosition()
+            return
+        }
+
+        let travelDirection: CGFloat = step > 0 ? -1 : 1
+        isTransitioningBetweenImages = true
+        view.isUserInteractionEnabled = false
+
+        UIView.animate(
+            withDuration: 0.14,
+            delay: 0,
+            options: [.curveEaseIn],
+            animations: {
+                self.scrollView.transform = CGAffineTransform(
+                    translationX: travelDirection * self.view.bounds.width * 0.22,
+                    y: 0
+                )
+                self.scrollView.alpha = 0
+            },
+            completion: { _ in
+                self.currentIndex = destination
+                self.scrollView.transform = CGAffineTransform(
+                    translationX: -travelDirection * self.view.bounds.width * 0.22,
+                    y: 0
+                )
+                self.displayCurrentItem()
+                self.scrollView.alpha = 0
+
+                UIView.animate(
+                    withDuration: 0.2,
+                    delay: 0,
+                    options: [.curveEaseOut],
+                    animations: {
+                        self.scrollView.transform = .identity
+                        self.scrollView.alpha = 1
+                    },
+                    completion: { _ in
+                        self.isTransitioningBetweenImages = false
+                        self.view.isUserInteractionEnabled = true
+                    }
+                )
+            }
+        )
+    }
+
+    private func restoreGalleryPosition() {
+        UIView.animate(
+            withDuration: 0.18,
+            delay: 0,
+            options: [.curveEaseOut],
+            animations: {
+                self.scrollView.transform = .identity
+            }
+        )
+    }
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer === swipeLeftGesture || gestureRecognizer === swipeRightGesture else {
+            return true
+        }
+
+        guard !isTransitioningBetweenImages,
+              items.count > 1,
+              abs(scrollView.zoomScale - minZoomScale) < 0.01 else {
+            return false
+        }
+
+        let step = gestureRecognizer === swipeLeftGesture ? 1 : -1
+        return FullScreenImageGalleryNavigation.destinationIndex(
+            currentIndex: currentIndex,
+            itemCount: items.count,
+            step: step
+        ) != nil
+    }
+
     @objc private func handleSingleTap() {
         // Toggle buttons visibility
         UIView.animate(withDuration: 0.3) {
-            self.buttonStackView.alpha = self.buttonStackView.alpha == 0 ? 1 : 0
+            let targetAlpha: CGFloat = self.buttonStackView.alpha == 0 ? 1 : 0
+            self.buttonStackView.alpha = targetAlpha
+            self.positionLabel.alpha = targetAlpha
         }
     }
     
@@ -221,7 +436,7 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
     
     @objc private func downloadImage() {
         // Prefer original bytes from network for best quality.
-        if let data = originalImageData {
+        if let data = originalImageDataByIndex[currentIndex] {
             saveImageDataToPhotoLibrary(data)
             return
         }
@@ -242,15 +457,17 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
     }
 
     private func loadOriginalImageIfAvailable() {
-        guard let originalImageURL else { return }
-        fetchOriginalImageData(from: originalImageURL)
+        let loadingIndex = currentIndex
+        let item = items[loadingIndex]
+        guard let originalImageURL = item.originalImageURL else { return }
+        fetchOriginalImageData(from: originalImageURL, itemIndex: loadingIndex)
 
         var options: KingfisherOptionsInfo = [
             .cacheOriginalImage,
             .transition(.fade(0.2))
         ]
 
-        if let token = sessionToken, !token.isEmpty {
+        if let token = item.sessionToken, !token.isEmpty {
             let modifier = AnyModifier { request in
                 var req = request
                 req.setValue(token, forHTTPHeaderField: "x-session-token")
@@ -265,29 +482,35 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
             options: options
         ) { [weak self] result in
             guard let self = self else { return }
+            guard self.currentIndex == loadingIndex else { return }
             if case .success(let value) = result {
                 // Keep fallback data even when raw-bytes fetch fails.
-                if self.originalImageData == nil {
-                    self.originalImageData = value.image.pngData() ?? value.image.jpegData(compressionQuality: 1.0)
+                if self.originalImageDataByIndex[loadingIndex] == nil {
+                    self.originalImageDataByIndex[loadingIndex] = value.image.pngData()
+                        ?? value.image.jpegData(compressionQuality: 1.0)
                 }
+                self.hasSetInitialZoom = false
                 self.setInitialZoomScale()
             }
         }
     }
 
-    private func fetchOriginalImageData(from url: URL) {
+    private func fetchOriginalImageData(from url: URL, itemIndex: Int) {
         var request = URLRequest(url: url)
-        if let token = sessionToken, !token.isEmpty {
+        if let token = items[itemIndex].sessionToken, !token.isEmpty {
             request.setValue(token, forHTTPHeaderField: "x-session-token")
         }
 
-        URLSession.shared.dataTask(with: request) { [weak self] data, response, _ in
-            guard let self = self, let data = data, !data.isEmpty else { return }
+        originalImageDataTask = URLSession.shared.dataTask(with: request) { [weak self] data, response, _ in
+            guard let data = data, !data.isEmpty else { return }
             if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
                 return
             }
-            self.originalImageData = data
-        }.resume()
+            DispatchQueue.main.async { [weak self] in
+                self?.originalImageDataByIndex[itemIndex] = data
+            }
+        }
+        originalImageDataTask?.resume()
     }
     
     private func saveImageToPhotoLibrary(_ image: UIImage) {
@@ -432,6 +655,32 @@ class FullScreenImageViewController: UIViewController, UIScrollViewDelegate {
     
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
         centerImageView()
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        guard !isTransitioningBetweenImages,
+              items.count > 1,
+              abs(scrollView.zoomScale - minZoomScale) < 0.01 else {
+            return
+        }
+
+        let translation = scrollView.panGestureRecognizer.translation(in: view)
+        let velocity = scrollView.panGestureRecognizer.velocity(in: view)
+        guard abs(translation.x) > abs(translation.y),
+              abs(translation.x) > 60 || abs(velocity.x) > 500 else {
+            return
+        }
+
+        let step = translation.x < 0 ? 1 : -1
+        guard let destination = FullScreenImageGalleryNavigation.destinationIndex(
+            currentIndex: currentIndex,
+            itemCount: items.count,
+            step: step
+        ) else {
+            return
+        }
+
+        transitionToImage(at: destination, step: step)
     }
     
     func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {

--- a/Revolt/Pages/Channel/Messagable/DataSources/MessageTableViewDataSource.swift
+++ b/Revolt/Pages/Channel/Messagable/DataSources/MessageTableViewDataSource.swift
@@ -96,12 +96,8 @@ class MessageTableViewDataSource: NSObject, UITableViewDataSource {
                     viewController?.handleMessageAction(action, message: message)
                 }
 
-                cell.onImageTapped = { [weak viewController] image, originalURL, sessionToken in
-                    viewController?.showFullScreenImage(
-                        image,
-                        originalImageURL: originalURL,
-                        sessionToken: sessionToken
-                    )
+                cell.onImageTapped = { [weak viewController] items, initialIndex in
+                    viewController?.showFullScreenImages(items, initialIndex: initialIndex)
                 }
 
                 if let viewController = viewController {
@@ -229,12 +225,8 @@ class LocalMessagesDataSource: NSObject, UITableViewDataSource {
                     viewControllerRef?.handleMessageAction(action, message: message)
                 }
 
-                cell.onImageTapped = { [weak viewControllerRef] image, originalURL, sessionToken in
-                    viewControllerRef?.showFullScreenImage(
-                        image,
-                        originalImageURL: originalURL,
-                        sessionToken: sessionToken
-                    )
+                cell.onImageTapped = { [weak viewControllerRef] items, initialIndex in
+                    viewControllerRef?.showFullScreenImages(items, initialIndex: initialIndex)
                 }
 
                 // Present user sheet on avatar tap

--- a/Revolt/Pages/Channel/Messagable/MessageableChannelViewController.swift
+++ b/Revolt/Pages/Channel/Messagable/MessageableChannelViewController.swift
@@ -1608,11 +1608,11 @@ class MessageableChannelViewController: UIViewController, UITextFieldDelegate,
     }
 
     // MARK: - Image Handling
-    func showFullScreenImage(_ image: UIImage, originalImageURL: URL?, sessionToken: String?) {
+    func showFullScreenImages(_ items: [FullScreenImageItem], initialIndex: Int) {
+        guard !items.isEmpty else { return }
         let imageViewController = FullScreenImageViewController(
-            image: image,
-            originalImageURL: originalImageURL,
-            sessionToken: sessionToken
+            items: items,
+            initialIndex: initialIndex
         )
         imageViewController.modalPresentationStyle = .overFullScreen
         present(imageViewController, animated: true, completion: nil)
@@ -2052,12 +2052,8 @@ class MessageableChannelViewController: UIViewController, UITextFieldDelegate,
                     viewController?.handleMessageAction(action, message: message)
                 }
 
-                messageCell.onImageTapped = { [weak viewController = viewControllerRef] image, originalURL, sessionToken in
-                    viewController?.showFullScreenImage(
-                        image,
-                        originalImageURL: originalURL,
-                        sessionToken: sessionToken
-                    )
+                messageCell.onImageTapped = { [weak viewController = viewControllerRef] items, initialIndex in
+                    viewController?.showFullScreenImages(items, initialIndex: initialIndex)
                 }
 
                 messageCell.onAvatarTap = { [weak viewModel = viewModelRef] in
@@ -3456,7 +3452,10 @@ class MessageableChannelViewController: UIViewController, UITextFieldDelegate,
 extension MessageCell {
     @objc func handleImageTap(_ gesture: UITapGestureRecognizer) {
         if let imageView = gesture.view as? UIImageView, let image = imageView.image {
-            onImageTapped?(image, nil, nil)
+            onImageTapped?(
+                [FullScreenImageItem(previewImage: image, originalImageURL: nil, sessionToken: nil)],
+                0
+            )
         }
     }
 }

--- a/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
+++ b/Revolt/Pages/Channel/Messagable/Views/MessageCell.swift
@@ -119,7 +119,7 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
     
     // Callback for message actions
     var onMessageAction: ((MessageAction, Message) -> Void)?
-    var onImageTapped: ((UIImage, URL?, String?) -> Void)?
+    var onImageTapped: (([FullScreenImageItem], Int) -> Void)?
     /// Called when async content (images, link previews) finishes loading and may have changed cell height.
     var onAsyncContentLoaded: ((String) -> Void)?
     var onAvatarTap: (() -> Void)?
@@ -1542,20 +1542,29 @@ class MessageCell: UITableViewCell, UITextViewDelegate {
     @objc internal func handleImageCellTap(_ gesture: UITapGestureRecognizer) {
         guard let imageView = gesture.view as? UIImageView,
               let image = imageView.image else { return }
-        
-        // Default fallback: still open preview if URL resolution fails
-        var originalURL: URL? = nil
-        var sessionToken: String? = nil
-        
-        
-        if let viewState = viewState,
-           let attachmentId = imageView.accessibilityIdentifier {
-            let urlString = viewState.formatUrl(fromId: attachmentId, withTag: "attachments")
-            originalURL = URL(string: urlString)
-            sessionToken = viewState.sessionToken
+
+        guard let viewState else {
+            onImageTapped?(
+                [FullScreenImageItem(previewImage: image, originalImageURL: nil, sessionToken: nil)],
+                0
+            )
+            return
         }
-        
-        onImageTapped?(image, originalURL, sessionToken)
+
+        let items = imageAttachmentViews.map { attachmentImageView in
+            let originalURL = attachmentImageView.accessibilityIdentifier.flatMap { attachmentId in
+                URL(string: viewState.formatUrl(fromId: attachmentId, withTag: "attachments"))
+            }
+            return FullScreenImageItem(
+                previewImage: attachmentImageView.image,
+                originalImageURL: originalURL,
+                sessionToken: viewState.sessionToken
+            )
+        }
+
+        guard !items.isEmpty else { return }
+        let initialIndex = min(max(0, imageView.tag), items.count - 1)
+        onImageTapped?(items, initialIndex)
     }
     
 

--- a/RevoltTests/RevoltTests.swift
+++ b/RevoltTests/RevoltTests.swift
@@ -211,6 +211,49 @@ final class RevoltTests: XCTestCase {
         )
     }
 
+    func testFullScreenGalleryNavigationMovesOneImageAndStopsAtBounds() {
+        XCTAssertEqual(
+            FullScreenImageGalleryNavigation.destinationIndex(
+                currentIndex: 1,
+                itemCount: 4,
+                step: 1
+            ),
+            2
+        )
+        XCTAssertEqual(
+            FullScreenImageGalleryNavigation.destinationIndex(
+                currentIndex: 2,
+                itemCount: 4,
+                step: -1
+            ),
+            1
+        )
+        XCTAssertNil(
+            FullScreenImageGalleryNavigation.destinationIndex(
+                currentIndex: 0,
+                itemCount: 4,
+                step: -1
+            )
+        )
+        XCTAssertNil(
+            FullScreenImageGalleryNavigation.destinationIndex(
+                currentIndex: 3,
+                itemCount: 4,
+                step: 1
+            )
+        )
+    }
+
+    func testFullScreenGalleryPositionTextOnlyAppearsForMultipleImages() {
+        XCTAssertEqual(
+            FullScreenImageGalleryNavigation.positionText(currentIndex: 1, itemCount: 4),
+            "2 of 4"
+        )
+        XCTAssertNil(
+            FullScreenImageGalleryNavigation.positionText(currentIndex: 0, itemCount: 1)
+        )
+    }
+
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {


### PR DESCRIPTION
## Summary

- open all image attachments from one message as a single full-screen gallery
- start at the image the user tapped
- swipe left or right one image at a time while the image is fitted
- preserve pinch/double-tap zoom and panning when zoomed
- show an accessible `x of y` position indicator
- keep downloads tied to the currently displayed original image

## Why

Messages with several images currently require closing the viewer and reopening each attachment. This matches the faster gallery interaction users expect from Discord and similar chat apps.

## Validation

- `xcodebuild -workspace Revolt.xcworkspace -scheme Revolt -destination 'id=D35643F6-F053-4A40-9D29-4A471E9900AC' SWIFT_VERSION=5 build -quiet`
- opened the production QA five-image message in the iOS 18.6 simulator
- verified the viewer fits the image immediately and reports the message-scoped position
- added boundary and position-label unit coverage

The shared scheme currently has no test action, so the XCTest target could not be launched through that scheme.